### PR TITLE
Generate seco256k1 keys uncompressed.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -152,7 +152,7 @@ lazy val legacy = (project in file("legacy"))
     libraryDependencies ++= common ++ tests ++ legacyLibs,
     resolvers += ("jitpack" at "https://jitpack.io"),
   )
-  .dependsOn(sdk, rholang, macros) // depends on new rholang implementation
+  .dependsOn(sdk, rholang, macros, secp256k1) // depends on new rholang implementation
 
 // Macro implementation should be compiled before macro application
 // https://stackoverflow.com/questions/75847326/macro-implementation-not-found-scala-2-13-3

--- a/legacy/src/main/scala/coop/rchain/crypto/signatures/Secp256k1.scala
+++ b/legacy/src/main/scala/coop/rchain/crypto/signatures/Secp256k1.scala
@@ -12,7 +12,7 @@ import cats.syntax.functor._
 import cats.syntax.applicativeError._
 import coop.rchain.crypto.util.SecureRandomUtil
 import coop.rchain.crypto.{PrivateKey, PublicKey}
-import org.bitcoin._
+import org.bitcoin.NativeSecp256k1
 import com.google.common.base.Strings
 import coop.rchain.shared.Base16
 import org.bouncycastle.asn1.DLSequence
@@ -144,7 +144,7 @@ object Secp256k1 extends SignaturesAlg {
     */
   def toPublic(seckey: Array[Byte]): Array[Byte] =
     // WARNING: this code throws Assertion exception if input is not correct length
-    NativeSecp256k1.computePubkey(seckey)
+    NativeSecp256k1.computePubkey(seckey, false)
 
   override def toPublic(sec: PrivateKey): PublicKey = PublicKey(toPublic(sec.bytes))
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -25,7 +25,6 @@ object Dependencies {
   val bouncyProvCastle   = "org.bouncycastle"            % "bcprov-jdk15on"   % "1.70"
   val bouncyPkixCastle   = "org.bouncycastle"            % "bcpkix-jdk15on"   % "1.70"
   val guava              = "com.google.guava"            % "guava"            % "31.1-jre"
-  val secp256k1Java      = "com.github.rchain"           % "secp256k1-java"   % "0.1"
   val scodecCore         = "org.scodec"                 %% "scodec-core"      % "1.11.10"
   val scodecCats         = "org.scodec"                 %% "scodec-cats"      % "1.2.0"
   val scodecBits         = "org.scodec"                 %% "scodec-bits"      % "1.1.37"
@@ -51,7 +50,6 @@ object Dependencies {
     protobuf,
     scalapbRuntimeLib,
     scalapbCompiler,
-    secp256k1Java,
     scodecCore,
     scodecCats,
     scodecBits,

--- a/secp256k1/src/main/java/org/bitcoin/NativeSecp256k1.java
+++ b/secp256k1/src/main/java/org/bitcoin/NativeSecp256k1.java
@@ -146,8 +146,7 @@ public class NativeSecp256k1 {
      * @return pubkey ECDSA Public key, 33 or 65 bytes
      * @throws NativeSecp256k1Util.AssertFailException if bad pubkey length
      */
-    // TODO add a 'compressed' arg
-    public static byte[] computePubkey(byte[] seckey) throws NativeSecp256k1Util.AssertFailException {
+    public static byte[] computePubkey(byte[] seckey, boolean compressed) throws NativeSecp256k1Util.AssertFailException {
         assert (seckey.length == 32);
 
         ByteBuffer byteBuff = nativeECDSABuffer.get();
@@ -163,7 +162,7 @@ public class NativeSecp256k1 {
 
         r.lock();
         try {
-            retByteArray = secp256k1_ec_pubkey_create(byteBuff, Secp256k1Context.getContext());
+            retByteArray = secp256k1_ec_pubkey_create(byteBuff, Secp256k1Context.getContext(), !compressed);
         } finally {
             r.unlock();
         }
@@ -489,7 +488,7 @@ public class NativeSecp256k1 {
 
     private static native int secp256k1_ec_seckey_verify(ByteBuffer byteBuff, long context);
 
-    private static native byte[][] secp256k1_ec_pubkey_create(ByteBuffer byteBuff, long context);
+    private static native byte[][] secp256k1_ec_pubkey_create(ByteBuffer byteBuff, long context, boolean uncompressed);
 
     private static native byte[][] secp256k1_ec_pubkey_parse(ByteBuffer byteBuff, long context, int inputLen);
 


### PR DESCRIPTION
## Overview

Generate seco256k1 keys uncompressed.

### Notes

<!-- Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else. -->

### Please make sure that this PR:

- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
