### PR TITLE
Optimize block sending to peers

### DIFF
--- a/db/src/main/scala/slick/Actions.scala
+++ b/db/src/main/scala/slick/Actions.scala
@@ -257,6 +257,9 @@ final case class Actions(profile: JdbcProfile, ec: ExecutionContext) {
       }
     }
 
+  def isBlockExist(hash: ByteArray): DBIOAction[Boolean, NoStream, Read] =
+    queries.blockIdByHash(hash.bytes).result.headOption.map(_.isDefined)
+
   /** DeploySet */
 
   /** Insert a new deploy set in table if there is no such entry. Returned id */

--- a/db/src/main/scala/slick/api/SlickApi.scala
+++ b/db/src/main/scala/slick/api/SlickApi.scala
@@ -125,4 +125,6 @@ class SlickApi[F[_]: Async](db: SlickDb, ec: ExecutionContext) {
         ),
       ),
     )
+
+  def isBlockExist(hash: ByteArray): F[Boolean] = actions.isBlockExist(hash).run
 }

--- a/node/src/main/scala/node/DbApiImpl.scala
+++ b/node/src/main/scala/node/DbApiImpl.scala
@@ -91,6 +91,8 @@ final case class DbApiImpl[F[_]: Sync](sApi: SlickApi[F]) {
     OptionT(sApi.blockGet(id)).semiflatMap(decode).value
   }
 
+  def isBlockExist(id: ByteArray): F[Boolean] = sApi.isBlockExist(id)
+
   def saveBalancesDeploy(d: BalancesDeploy): F[Unit] = sApi.deployInsert(
     sdk.data.Deploy(
       sig = d.id,

--- a/node/src/main/scala/node/Setup.scala
+++ b/node/src/main/scala/node/Setup.scala
@@ -143,6 +143,10 @@ object Setup {
         genesisPoS.pure[F] // TODO for now PoS is static defined in genesis
     }
 
+    val dbApiImpl = DbApiImpl(database)
+    val saveBlock = dbApiImpl.saveBlock _
+    val readBlock = dbApiImpl.readBlock(_: ByteArray).flatMap(_.liftTo[F](new Exception("Block not found")))
+
     DProc
       .apply[F, ByteArray, ByteArray, BalancesDeploy](
         state.weaverStRef,
@@ -154,8 +158,8 @@ object Setup {
         exeEngine,
         Relation.notRelated[F, BalancesDeploy],
         b => Sync[F].delay(ByteArray(Blake2b.hash256(b.digest.bytes))),
-        DbApiImpl(database).saveBlock,
-        DbApiImpl(database).readBlock(_).flatMap(_.liftTo[F](new Exception("Block not found"))),
+        saveBlock,
+        readBlock,
       )
   })
 


### PR DESCRIPTION
## Overview

Optimization of sending a block to peers is performed. Before saving a block, each peer checks whether the peer's database contains this block. The `isBlockExist` function has been added to the API for checking. There is also a check in the `saveBlock` function itself, but it has overhead for checking deployments, creating a block, etc., so it is more efficient to use a separate function for checking. Also, saving blocks for peers is done in parallel.

Optimized creation of `DbApiImpl` instances.

### Please make sure that this PR:

- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
