### PR TITLE
Build docker image for node

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,6 @@ vdags/
 .lmdb/
 # All reference config files should be reference.conf, application.conf containing secrets is ignored
 *application.conf
+
+# Ignore docker env files
+*.env

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,16 @@
+version: '3.8'
+services:
+  db:
+    image: postgres
+    env_file:
+      - node.env
+    ports:
+      - "5433:5432"
+  node:
+    image: node:0.1.0-SNAPSHOT
+    depends_on:
+      - db
+    env_file:
+      - node.env
+    ports:
+      - "8081:8080"

--- a/node/src/main/resources/logback.xml
+++ b/node/src/main/resources/logback.xml
@@ -1,0 +1,8 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/node/src/main/scala/node/Main.scala
+++ b/node/src/main/scala/node/Main.scala
@@ -14,12 +14,13 @@ import sdk.reflect.ClassesAsConfig
 import sdk.syntax.all.*
 import slick.SlickPgDatabase
 import weaver.data.{Bonds, FinalData}
+import node.BuildInfo
 
 object Main extends IOApp {
-  private val DbUrlKey     = "gorki.db.url"
-  private val DbUser       = "gorki.db.user"
-  private val DbPasswd     = "gorki.db.passwd"
-  private val ValidatorKey = "gorki.validator.sKey"
+  private val DbUrlKey     = "gorki_db_url"
+  private val DbUser       = "gorki_db_user"
+  private val DbPasswd     = "gorki_db_passwd"
+  private val ValidatorKey = "gorki_validator_sKey"
 
   private val DefaultNodeId = "e211d1b7e8018b567af18dd25377cb4eb0cf2688eb49aba505682b1ddb647a4e"
 
@@ -67,6 +68,9 @@ object Main extends IOApp {
         IO.println(referenceConf).as(ExitCode.Success)
       case _                              =>
         configWithEnv[IO].flatMap { case (dbCfg, nodeId) =>
+          val version = s"Node ${BuildInfo.version} (${BuildInfo.gitHeadCommit.getOrElse("commit # unknown")})"
+          println(version)
+
           /// Genesis data
           val genesisPoS = {
             val lazinessTolerance = 1

--- a/node/src/test/scala/node/GrpcDslCommSpec.scala
+++ b/node/src/test/scala/node/GrpcDslCommSpec.scala
@@ -25,5 +25,6 @@ class GrpcDslCommSpec extends AnyFlatSpec with Matchers {
     val grpcCall      = GrpcClient[IO].call(GrpcMethod(protocol), srcMessage, clientChannel)
 
     grpcServer.use(_ => grpcCall.map(resp => resp shouldBe expectedResponse)).unsafeRunSync()
+    clientChannel.shutdown()
   }
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,8 @@
-addSbtPlugin("org.wartremover"    % "sbt-wartremover"    % "3.1.3")
-addSbtPlugin("org.scalameta"      % "sbt-scalafmt"       % "2.4.0")
-addSbtPlugin("ch.epfl.scala"      % "sbt-scala3-migrate" % "0.5.1") // Temp for migration to Scala 3
-addSbtPlugin("pl.project13.scala" % "sbt-jmh"            % "0.4.5")
-addSbtPlugin("com.eed3si9n"       % "sbt-assembly"       % "0.14.10")
+addSbtPlugin("org.wartremover"    % "sbt-wartremover"     % "3.1.3")
+addSbtPlugin("org.scalameta"      % "sbt-scalafmt"        % "2.4.0")
+addSbtPlugin("ch.epfl.scala"      % "sbt-scala3-migrate"  % "0.5.1") // Temp for migration to Scala 3
+addSbtPlugin("pl.project13.scala" % "sbt-jmh"             % "0.4.5")
+addSbtPlugin("com.eed3si9n"       % "sbt-assembly"        % "0.14.10")
+addSbtPlugin("com.typesafe.sbt"   % "sbt-native-packager" % "1.3.12")
+addSbtPlugin("com.eed3si9n"       % "sbt-buildinfo"       % "0.11.0")
+addSbtPlugin("com.github.sbt"     % "sbt-git"             % "2.0.1")


### PR DESCRIPTION
## Overview

Add commands to build docker image for node.

To build the node's executable file, the `sbt-native-packager` library is used.

Added a sequence of commands to build `Dockerfile` and then image based on the `azul/zulu-openjdk:18-jre` image, which installs the SBT version specified in `project/build.properties`, unpacks the project sources and builds.

In order to ensure that the node works with the database, an additional `postgres` image has been added. Creation of images is combined in `docker-compose.yaml`. The most current syntax, version `3.8`, is used. Ports are configured so as not to conflict with host ports.

Fixed writing and reading the dbVersion parameter and gRPC exchange test.

To build docker image run such command from SBT
```sbt
project node
docker:publishLocal
```

To start images run this command from repository root
```bash
docker-compose up
```

Also implemented display of the application version and git-commit hash. For this, the SBT plugins `sbt-buildinfo` and `sbt-git` are used.

The logging level `INFO` is set up for the `node` project so as not to clutter the output with debug messages.

### Please make sure that this PR:

- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
