### PR TITLE
Add Zipkin tracing support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -47,7 +47,9 @@ lazy val gorkiNode = (project in file("."))
 lazy val sdk = (project in file("sdk"))
 //  .settings(settingsScala3*) // Not supported in IntelliJ Scala plugin
   .settings(settingsScala2*)
-  .settings(libraryDependencies ++= common ++ dbLibs ++ tests ++ log :+ protobuf :+ bouncyProvCastle :+ magnolia1)
+  .settings(
+    libraryDependencies ++= common ++ dbLibs ++ tests ++ diagnostics ++ log :+ protobuf :+ bouncyProvCastle :+ magnolia1,
+  )
 
 // Database interfaces implementation
 lazy val db = (project in file("db"))
@@ -82,7 +84,7 @@ lazy val node = (project in file("node"))
       protobuf,
       grpc,
       grpcNetty,
-    ) ++ tests ++ log ++ http4s ++ endpoints4s :+ lmdbjava :+ enumeratum :+ pureConfig,
+    ) ++ tests ++ log ++ http4s ++ endpoints4s ++ diagnostics :+ lmdbjava :+ enumeratum :+ pureConfig,
     resolvers ++=
       // for embedded InfluxDB
       Resolver.sonatypeOssRepos("releases") ++

--- a/db/src/main/scala/slick/SlickDb.scala
+++ b/db/src/main/scala/slick/SlickDb.scala
@@ -1,5 +1,6 @@
 package slick
 
+import cats.Parallel
 import cats.effect.kernel.Async
 import cats.syntax.all.*
 import io.circe.syntax.*
@@ -20,7 +21,7 @@ final case class SlickDb private (private val db: Database, profile: JdbcProfile
 }
 
 object SlickDb {
-  def apply[F[_]: Async](
+  def apply[F[_]: Async: Parallel](
     db: Database,
     profile: JdbcProfile,
     dialect: Dialect[?],

--- a/node/src/main/scala/node/DbApiImpl.scala
+++ b/node/src/main/scala/node/DbApiImpl.scala
@@ -115,7 +115,7 @@ final case class DbApiImpl[F[_]: Sync: Span](sApi: SlickApi[F]) {
 
   def isBlockExist(id: ByteArray): F[Boolean] = sApi.isBlockExist(id)
 
-  def saveBalancesDeploy(d: BalancesDeploy): F[Unit] = sApi.deployInsert(
+  def saveBalancesDeploy(d: BalancesDeploy, ctx: TraceContext): F[Unit] = sApi.deployInsert(
     sdk.data.Deploy(
       sig = d.id,
       deployerPk = DeployerPkDefault,
@@ -125,6 +125,7 @@ final case class DbApiImpl[F[_]: Sync: Span](sApi: SlickApi[F]) {
       phloLimit = PhloLimitDefault,
       nonce = d.body.vabn,
     ),
+    ctx,
   )
 
   def readBalancesDeploy(id: ByteArray): F[Option[BalancesDeploy]] =

--- a/node/src/main/scala/node/Main.scala
+++ b/node/src/main/scala/node/Main.scala
@@ -5,18 +5,19 @@ import cats.effect.kernel.Ref.Make
 import cats.effect.std.{Env, Random}
 import cats.syntax.all.*
 import node.Hashing.*
-import sdk.serialize.auto.*
 import sdk.codecs.Base16
 import sdk.data.{BalancesDeploy, BalancesDeployBody, BalancesState, HostWithPort}
 import sdk.error.FatalError
 import sdk.log.Logger.*
 import sdk.primitive.ByteArray
 import sdk.reflect.ClassesAsConfig
+import sdk.serialize.auto.*
 import sdk.syntax.all.*
 import slick.SlickPgDatabase
 import weaver.data.{Bonds, FinalData}
 
 import java.net.InetAddress
+import scala.concurrent.duration.DurationInt
 
 object Main extends IOApp {
   private val DbUrlKey      = "gorki_db_url"
@@ -77,6 +78,8 @@ object Main extends IOApp {
       case _                              =>
         val mainStreamF = for {
           _               <- logInfoF[IO](s"Node version: ${NodeBuildInfo()}")
+          // A trick to ensure that zipkin in a virtual docker network starts early and is ready for external connections
+          _               <- cats.effect.Temporal[IO].sleep(5.seconds)
           c               <- configWithEnv[IO]
           bootstrpOpt     <- Env[IO].get(BootstrapAddr)
           (dbCfg, nodeId)  = c

--- a/node/src/main/scala/node/Setup.scala
+++ b/node/src/main/scala/node/Setup.scala
@@ -72,7 +72,7 @@ final case class Setup[F[_]](
 )
 
 object Setup {
-  private def database[F[_]: Async](dbDef: Resource[F, DatabaseDef]): Resource[F, SlickApi[F]] =
+  private def database[F[_]: Async: Parallel](dbDef: Resource[F, DatabaseDef]): Resource[F, SlickApi[F]] =
     dbDef.evalMap(x => SlickDb(x, PostgresProfile, new PostgresDialect).flatMap(SlickApi[F]))
 
   private def kvDiskStoreManager[F[_]: Async](dataDir: Path): Resource[F, KeyValueStoreManager[F]] =

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -84,6 +84,11 @@ object Dependencies {
   val kamonInfluxDbReporter = "io.kamon"    %% "kamon-influxdb"       % "2.6.0"
   val kamonJaegerReporter   = "io.kamon"    %% "kamon-jaeger"         % "2.6.0"
   val influxDbClient        = "com.influxdb" % "influxdb-client-java" % "6.10.0"
+  val zipkin: Seq[ModuleID] = Seq(
+    "io.zipkin.brave"     % "brave"                 % "5.13.2", // TODO: Is it actual version?
+    "io.zipkin.reporter2" % "zipkin-sender-okhttp3" % "2.15.2", // TODO: Is it actual version?
+    "io.zipkin.reporter2" % "zipkin-reporter"       % "2.15.2", // TODO: Is it actual version?
+  )
 
   // Logging
   val logbackClassic   = "ch.qos.logback"              % "logback-classic" % "1.4.7"
@@ -133,7 +138,7 @@ object Dependencies {
 
   val common = Seq(catsCore, catsEffect, fs2Core, jaxb, kindProjector, circeGeneric, circeParser, apacheCommonsIO)
 
-  val diagnostics = Seq(kamonBundle, kamonInfluxDbReporter, kamonJaegerReporter, influxDbClient)
+  val diagnostics = Seq(kamonBundle, kamonInfluxDbReporter, kamonJaegerReporter, influxDbClient) ++ zipkin
 
   val log = Seq(logbackClassic, typesagfeLogging)
 

--- a/run.py
+++ b/run.py
@@ -1,0 +1,52 @@
+from collections import defaultdict
+
+import matplotlib.pyplot as plt
+import requests
+
+
+def aggregate_data(data):
+    # trace_data = [(span['name'], span['duration']) for trace in data for span in trace]
+    trace_data = []
+    for trace in data:
+        for span in trace:
+            try:
+                trace_data.append((span['name'], span['duration']))
+            except:
+                print(span)
+
+    aggregated_data = defaultdict(lambda: {'sum': 0, 'count': 0})
+    for span_name, duration in trace_data:
+        aggregated_data[span_name]['sum'] += duration
+        aggregated_data[span_name]['count'] += 1
+
+    # average_durations = [(span_name, info['sum'] / info['count']) for span_name, info in
+    #                      aggregated_data.items()]
+    durations = [(span_name, info['sum']) for span_name, info in aggregated_data.items()]
+    return sorted(durations, key=lambda x: x[1], reverse=True)
+
+
+def show_diagram(data: list):
+    labels = [item[0] for item in data]
+    values = [item[1] for item in data]
+
+    plt.figure(figsize=(10, 8))
+    plt.barh(labels, values)
+    plt.xlabel('Values')
+    plt.ylabel('Operations')
+    plt.title('Operations bar chart')
+    plt.gca().invert_yaxis()
+    plt.grid(True)
+    plt.subplots_adjust(left=0.305, right=0.980, bottom=0.065, top=0.955)
+
+    plt.show()
+
+
+if __name__ == '__main__':
+    response = requests.get('http://127.0.0.1:9411/zipkin/api/v2/traces?serviceName=Node&limit=1000')
+    if response.status_code == 200:
+        try:
+            data = response.json()
+            sorted_data = aggregate_data(data)
+            show_diagram(sorted_data)
+        except ValueError:
+            print('JSON decoding error')

--- a/sdk/src/main/scala/sdk/diag/Zipkin.scala
+++ b/sdk/src/main/scala/sdk/diag/Zipkin.scala
@@ -1,0 +1,71 @@
+package sdk.diag
+
+import brave.Tracing
+import brave.propagation.TraceContext
+import cats.effect.{Resource, Sync}
+import zipkin2.reporter.brave.AsyncZipkinSpanHandler
+import zipkin2.reporter.okhttp3.OkHttpSender
+
+trait Span[F[_]] {
+  def traceF[A](source: String, parentContext: Option[TraceContext] = None)(block: brave.Span => F[A]): F[A]
+  def trace[A](source: String, parentContext: Option[TraceContext] = None)(block: brave.Span => A): A
+}
+
+object Span {
+  def apply[F[_]](implicit ev: Span[F]): Span[F] = ev
+}
+
+final class ZipkinSpan[F[_]: Sync](implicit tracing: Tracing) extends Span[F] {
+  override def traceF[A](source: String, parentContext: Option[TraceContext] = None)(block: brave.Span => F[A]): F[A] =
+    Zipkin.traceF(source, parentContext)(block)
+
+  override def trace[A](source: String, parentContext: Option[TraceContext])(block: brave.Span => A): A =
+    Zipkin.trace(source, parentContext)(block)
+}
+
+object Zipkin {
+  // Run `docker run -d -p 9411:9411 openzipkin/zipkin` from Terminal to start Zipkin UI
+  def apply[F[_]: Sync]: Resource[F, ZipkinSpan[F]] = Resource
+    .make {
+      Sync[F].delay {
+        val sender            = OkHttpSender.create("http://zipkin:9411/api/v2/spans")
+        val zipkinSpanHandler = AsyncZipkinSpanHandler.create(sender)
+        val tracing           = Tracing
+          .newBuilder()
+          .localServiceName("Node")
+          .addSpanHandler(zipkinSpanHandler)
+          .build()
+        (zipkinSpanHandler, tracing)
+      }
+    } { case (_, tracing) => Sync[F].delay(tracing.close()) }
+    .map { case (_, tracing) =>
+      implicit val t = tracing
+      new ZipkinSpan[F]()
+    }
+
+  def traceF[F[_]: Sync, A](operationName: String, parentContext: Option[TraceContext] = None)(
+    io: brave.Span => F[A],
+  )(implicit tracing: Tracing): F[A] = Resource
+    .make {
+      Sync[F].delay {
+        val span = parentContext match {
+          case Some(ctx) => tracing.tracer().newChild(ctx).name(operationName).start()
+          case None      => tracing.tracer().nextSpan().name(operationName).start()
+        }
+        span
+      }
+    }(span => Sync[F].delay(span.finish()))
+    .use(span => io(span))
+
+  def trace[A](operationName: String, parentContext: Option[TraceContext] = None)(
+    io: brave.Span => A,
+  )(implicit tracing: Tracing): A = {
+    val span   = parentContext match {
+      case Some(ctx) => tracing.tracer().newChild(ctx).name(operationName).start()
+      case None      => tracing.tracer().nextSpan().name(operationName).start()
+    }
+    val result = io(span)
+    span.finish()
+    result
+  }
+}

--- a/sim/docker-compose/shard4.yaml
+++ b/sim/docker-compose/shard4.yaml
@@ -20,6 +20,8 @@ x-node: &default-node
     - ./logback.xml:/var/lib/gorki/logback.xml
   networks:
     - sim-net
+  depends_on:
+    - zipkin
 
 
 x-db: &default-db
@@ -30,6 +32,15 @@ x-db: &default-db
     - sim-net
 
 services:
+  zipkin:
+    image: openzipkin/zipkin
+    environment:
+      JAVA_OPTS: "-Xms512m -Xmx2g"
+    ports:
+      - "9411:9411"
+    networks:
+      - sim-net
+
   db0:
     <<: *default-db
     ports:

--- a/sim/src/main/scala/sim/NetworkSim.scala
+++ b/sim/src/main/scala/sim/NetworkSim.scala
@@ -6,15 +6,11 @@ import cats.effect.unsafe.implicits.global
 import cats.syntax.all.*
 import node.{ConfigManager, Setup}
 import sdk.comm.Peer
-import sdk.data.BalancesState
-import sdk.hashing.Blake2b
-import sdk.primitive.ByteArray
-import slick.{SlickDb, SlickPgDatabase}
 import slick.api.SlickApi
 import slick.jdbc.JdbcBackend.Database
 import slick.jdbc.PostgresProfile
 import slick.migration.api.PostgresDialect
-import weaver.data.{Bonds, FinalData}
+import slick.{SlickDb, SlickPgDatabase}
 
 import java.nio.file.Path
 
@@ -97,8 +93,8 @@ object NetworkSim extends IOApp {
             // set empty peers so nodes do not broadcast blocks through grpc servers.
             // Simulation uses shared memory for this.
             db.evalMap { d =>
-              import io.circe.generic.auto.*
               import ConfigManager.*
+              import io.circe.generic.auto.*
 
               val peersCfg =
                 node.comm.Config.Default.copy(peers = peers.updated(idx, peers(idx).copy(isSelf = true)).values.toList)


### PR DESCRIPTION
## Overview

Added Zipkin support for tracing code execution in a node.

Nested Span are supported.

Zipkin runs from a docker image on a shared `sim-net` network. You can view the latest traces at http://127.0.0.1:9411/zipkin/api/v2/traces?serviceName=Node

Added a Python script that allows you to build a bar graph of the total time of spans. Example:

![image](https://github.com/nzpr/gorki-node/assets/1443855/80dca4a6-102a-4a36-bbad-dce096ae3486)

From analyzing the Zipkin trace, it appears that preparing `DBIOAction` is fast, but executing `DBIOAction` takes a long time. Most likely, execution occurs at the Postgres level, and it will not be possible to speed up the code here.

![image](https://github.com/nzpr/gorki-node/assets/1443855/27b70a9e-9b02-45e4-9dea-7334d93f1e7d)

On the other hand, when inserting a block, additional data is pre-inserted. An attempt was made to insert them in parallel before inserting the block, but judging by performance measurements, this did not have an effect.

### Please make sure that this PR:

- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
