### PR TITLE
Direct de Bruijn indices numeration

### DIFF
--- a/legacy/src/main/scala/coop/rchain/rholang/interpreter/Env.scala
+++ b/legacy/src/main/scala/coop/rchain/rholang/interpreter/Env.scala
@@ -4,8 +4,7 @@ final case class Env[A](envMap: Map[Int, A], level: Int, shift: Int) {
   def put(a: A): Env[A] =
     Env(envMap + (level -> a), level + 1, shift)
 
-  def get(k: Int): Option[A] =
-    envMap.get(level + shift - k - 1)
+  def get(k: Int): Option[A] = envMap.get(k)
 
   def shift(j: Int): Env[A] =
     this.copy(shift = shift + j)

--- a/legacy/src/main/scala/coop/rchain/rholang/interpreter/PrettyPrinter.scala
+++ b/legacy/src/main/scala/coop/rchain/rholang/interpreter/PrettyPrinter.scala
@@ -18,17 +18,16 @@ import io.rhonix.rholang.types.ParN
 import scalapb.GeneratedMessage
 
 object PrettyPrinter {
-  def apply(): PrettyPrinter = PrettyPrinter(0, 0)
+  def apply(): PrettyPrinter = PrettyPrinter(0)
 
-  def apply(freeShift: Int, boundShift: Int): PrettyPrinter =
-    PrettyPrinter(freeShift, boundShift, Vector.empty[Int], "free", "a", 23, 128)
+  def apply(boundShift: Int): PrettyPrinter =
+    PrettyPrinter(boundShift, Vector.empty[Int], "free", "a", 23, 128)
 
   implicit class CappedOps(private val str: String) extends AnyVal {
     def cap() = Printer.OUTPUT_CAPPED.map(n => s"${str.take(n)}...").getOrElse(str)
   }
 }
 final case class PrettyPrinter(
-  freeShift: Int, // TODO: Remove it
   boundShift: Int,
   newsShiftIndices: Vector[Int],
   freeId: String,
@@ -37,15 +36,6 @@ final case class PrettyPrinter(
   maxVarCount: Int,
   isBuildingChannel: Boolean = false,
 ) {
-
-  // TEMP: Gets variable index. Legacy variant is to support existing reducer logic.
-  private def varLevel(level: Int) =
-    if (Normalizer.BOUND_VAR_INDEX_REVERSED)
-      // 1. legacy reducer expects index from end
-      boundShift - level - 1
-    else
-      // 2. directly return index
-      level
 
   val indentStr = "  "
 
@@ -162,7 +152,7 @@ final case class PrettyPrinter(
       case FreeVar(level)    => Eval.now(s"$freeId$level")
       case BoundVar(level)   =>
         (if (isNewVar(level) && !isBuildingChannel) Eval.now("*") else Eval.now("")) |+| Eval.now(
-          s"$boundId${varLevel(level)}",
+          s"$boundId$level",
         )
       case Wildcard(_)       => Eval.now("_")
       case VarInstance.Empty => Eval.now("@Nil")
@@ -209,7 +199,6 @@ final case class PrettyPrinter(
             val bindString =
               this
                 .copy(
-                  freeShift = boundShift,
                   boundShift = 0,
                   freeId = boundId,
                   baseId = setBaseId(),
@@ -371,7 +360,6 @@ final case class PrettyPrinter(
     val closeBrace       = Eval.now(s"\n${indentStr * indent}}")
     this
       .copy(
-        freeShift = boundShift,
         boundShift = 0,
         freeId = boundId,
         baseId = setBaseId(),
@@ -393,5 +381,5 @@ final case class PrettyPrinter(
       p.bundles.isEmpty &
       p.connectives.isEmpty
 
-  private def isNewVar(level: Int): Boolean = newsShiftIndices.contains(varLevel(level))
+  private def isNewVar(level: Int): Boolean = newsShiftIndices.contains(level)
 }

--- a/legacy/src/main/scala/coop/rchain/rholang/interpreter/PrettyPrinter.scala
+++ b/legacy/src/main/scala/coop/rchain/rholang/interpreter/PrettyPrinter.scala
@@ -28,7 +28,7 @@ object PrettyPrinter {
   }
 }
 final case class PrettyPrinter(
-  freeShift: Int,
+  freeShift: Int, // TODO: Remove it
   boundShift: Int,
   newsShiftIndices: Vector[Int],
   freeId: String,
@@ -159,7 +159,7 @@ final case class PrettyPrinter(
 
   private def buildStringM(v: Var): Eval[String] =
     v.varInstance match {
-      case FreeVar(level)    => Eval.now(s"$freeId${freeShift + level}")
+      case FreeVar(level)    => Eval.now(s"$freeId$level")
       case BoundVar(level)   =>
         (if (isNewVar(level) && !isBuildingChannel) Eval.now("*") else Eval.now("")) |+| Eval.now(
           s"$boundId${varLevel(level)}",

--- a/legacy/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
+++ b/legacy/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
@@ -355,7 +355,7 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: CostStateRef](
   ): M[Unit] = {
 
     def addToEnv(env: Env[Par], freeMap: Map[Int, Par], freeCount: Int): Env[Par] =
-      Range(0, freeCount).foldLeft(env)((acc, e) => acc.put(freeMap.getOrElse(e, Par())))
+      Range(0, freeCount).foldLeft(env)((acc, e) => acc.put(freeMap.getOrElse(e + env.level, Par())))
 
     def firstMatch(target: Par, cases: Seq[MatchCase])(implicit env: Env[Par]): M[Unit] = {
       def firstMatchM(

--- a/legacy/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
+++ b/legacy/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
@@ -2,7 +2,7 @@ package coop.rchain.rholang.interpreter
 
 import cats.effect.{Ref, Sync}
 import cats.syntax.all._
-import cats.{Parallel, Eval => _}
+import cats.{Eval => _, Parallel}
 import com.google.protobuf.ByteString
 import coop.rchain.crypto.hash.Blake2b512Random
 import coop.rchain.models.Expr.ExprInstance._
@@ -43,17 +43,25 @@ trait Reduce[M[_]] {
 
 }
 
+/**
+ * Case class representing matched pars with a random state.
+ *
+ * @param pars A map where the keys are de Bruijn indices of free variables from the pattern and the values are the data that the matcher associated with them.
+ * @param randomState The random state ensuring the uniqueness of this data.
+ */
+final case class MatchedParsWithRandom(pars: matcher.FreeMap, randomState: Blake2b512Random)
+
 class DebruijnInterpreter[M[_]: Sync: Parallel: CostStateRef](
-    space: RhoTuplespace[M],
-    dispatcher: => RhoDispatch[M],
-    urnMap: Map[String, Par],
-    mergeChs: Ref[M, Set[Par]],
-    mergeableTagName: Par
+  space: RhoTuplespace[M],
+  dispatcher: => RhoDispatch[M],
+  urnMap: Map[String, Par],
+  mergeChs: Ref[M, Set[Par]],
+  mergeableTagName: Par,
 ) extends Reduce[M] {
 
   type Application =
     Option[
-      (TaggedContinuation, Seq[(Par, ListParWithRandom, ListParWithRandom, Boolean)], Boolean)
+      (TaggedContinuation, Seq[(Par, MatchedParsWithRandom, ListParWithRandom, Boolean)], Boolean),
     ]
 
   /**
@@ -64,16 +72,16 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: CostStateRef](
     * @param persistent  True if the write should remain in the tuplespace indefinitely.
     */
   private def produce(
-      chan: Par,
-      data: ListParWithRandom,
-      persistent: Boolean
+    chan: Par,
+    data: ListParWithRandom,
+    persistent: Boolean,
   ): M[Unit] =
     updateMergeableChannels(chan) *>
       space.produce(chan, data, persist = persistent) >>= { produceResult =>
       continue(
         unpackOptionWithPeek(produceResult),
         produce(chan, data, persistent),
-        persistent
+        persistent,
       )
     }
 
@@ -85,10 +93,10 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: CostStateRef](
     * @param body  A Par object which will be run in the envirnoment resulting from the match.
     */
   private def consume(
-      binds: Seq[(BindPattern, Par)],
-      body: ParWithRandom,
-      persistent: Boolean,
-      peek: Boolean
+    binds: Seq[(BindPattern, Par)],
+    body: ParWithRandom,
+    persistent: Boolean,
+    peek: Boolean,
   ): M[Unit] = {
     val (patterns: Seq[BindPattern], sources: Seq[Par]) = binds.unzip
 
@@ -98,12 +106,12 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: CostStateRef](
         patterns.toList,
         TaggedContinuation(ParBody(body)),
         persist = persistent,
-        if (peek) SortedSet(sources.indices: _*) else SortedSet.empty[Int]
+        if (peek) SortedSet(sources.indices: _*) else SortedSet.empty[Int],
       ) >>= { consumeResult =>
       continue(
         unpackOptionWithPeek(consumeResult),
         consume(binds, body, persistent, peek),
-        persistent
+        persistent,
       )
     }
   }
@@ -112,42 +120,41 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: CostStateRef](
     res match {
       case Some((continuation, dataList, _)) if persistent =>
         dispatchAndRun(continuation, dataList)(
-          repeatOp
+          repeatOp,
         )
-      case Some((continuation, dataList, peek)) if peek =>
+      case Some((continuation, dataList, peek)) if peek    =>
         dispatchAndRun(continuation, dataList)(
-          producePeeks(dataList): _*
+          producePeeks(dataList): _*,
         )
-      case Some((continuation, dataList, _)) =>
+      case Some((continuation, dataList, _))               =>
         dispatch(continuation, dataList)
-      case None => Sync[M].unit
+      case None                                            => Sync[M].unit
     }
 
   private[this] def dispatchAndRun(
-      continuation: TaggedContinuation,
-      dataList: Seq[(Par, ListParWithRandom, ListParWithRandom, Boolean)]
+    continuation: TaggedContinuation,
+    dataList: Seq[(Par, MatchedParsWithRandom, ListParWithRandom, Boolean)],
   )(ops: M[Unit]*): M[Unit] =
     // Collect errors from all parallel execution paths (pars)
     parTraverseSafe(dispatch(continuation, dataList) +: ops.toVector)(identity)
 
   private[this] def dispatch(
-      continuation: TaggedContinuation,
-      dataList: Seq[(Par, ListParWithRandom, ListParWithRandom, Boolean)]
+    continuation: TaggedContinuation,
+    dataList: Seq[(Par, MatchedParsWithRandom, ListParWithRandom, Boolean)],
   ): M[Unit] = dispatcher.dispatch(
     continuation,
-    dataList.map(_._2)
+    dataList.map(_._2),
   )
 
   private[this] def producePeeks(
-      dataList: Seq[(Par, ListParWithRandom, ListParWithRandom, Boolean)]
+    dataList: Seq[(Par, MatchedParsWithRandom, ListParWithRandom, Boolean)],
   ): Seq[M[Unit]] =
     dataList
-      .withFilter {
-        case (_, _, _, persist) => !persist
+      .withFilter { case (_, _, _, persist) =>
+        !persist
       }
-      .map {
-        case (chan, _, removedData, _) =>
-          produce(chan, removedData, persistent = false)
+      .map { case (chan, _, removedData, _) =>
+        produce(chan, removedData, persistent = false)
       }
 
   /* Collect mergeable channels */
@@ -168,9 +175,9 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: CostStateRef](
     * particular concurrency semantics is desired, it should be achieved by modifying the `Parallel` instance, not by
     * modifying this method.
     */
-  override def eval(par: Par)(
-      implicit env: Env[Par],
-      rand: Blake2b512Random
+  override def eval(par: Par)(implicit
+    env: Env[Par],
+    rand: Blake2b512Random,
   ): M[Unit] = {
     val terms: Seq[GeneratedMessage] = Seq(
       par.sends,
@@ -184,7 +191,7 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: CostStateRef](
           case _: EMethodBody => true
           case _              => false
         }
-      }
+      },
     ).filter(_.nonEmpty).flatten
 
     def split(id: Int): Blake2b512Random =
@@ -197,14 +204,13 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: CostStateRef](
     val termSplitLimit = Short.MaxValue
     if (terms.sizeIs > termSplitLimit.toInt)
       ReduceError(
-        s"The number of terms in the Par is ${terms.size}, which exceeds the limit of ${termSplitLimit}."
+        s"The number of terms in the Par is ${terms.size}, which exceeds the limit of ${termSplitLimit}.",
       ).raiseError[M, Unit]
     else {
 
       // Collect errors from all parallel execution paths (pars)
-      parTraverseSafe(terms.zipWithIndex.toVector) {
-        case (term, index) =>
-          eval(term)(env, split(index))
+      parTraverseSafe(terms.zipWithIndex.toVector) { case (term, index) =>
+        eval(term)(env, split(index))
       }
     }
   }
@@ -224,7 +230,7 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: CostStateRef](
       OutOfPhlogistonsError.raiseError[M, Unit]
 
     // Rethrow single error
-    case Vector(ex) =>
+    case Vector(ex)                                         =>
       ex match {
         // Rethrow ArithmeticException as ReduceError
         // TODO: quick fix for arithmetic errors in reducer to not be fatal
@@ -235,7 +241,7 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: CostStateRef](
       }
 
     // Collect errors from parallel execution
-    case errList =>
+    case errList                                            =>
       val (interpErrs, errs) = errList.foldLeft((Vector[InterpreterError](), Vector[Throwable]())) {
         // Concat nested errors
         case ((ipErr1, err1), AggregateError(ipErr2, err2)) => (ipErr1 ++ ipErr2, err1 ++ err2)
@@ -246,7 +252,7 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: CostStateRef](
   }
 
   private def eval(
-      term: GeneratedMessage
+    term: GeneratedMessage,
   )(implicit env: Env[Par], rand: Blake2b512Random): M[Unit] =
     term match {
       case term: Send    => eval(term)
@@ -254,13 +260,13 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: CostStateRef](
       case term: New     => eval(term)
       case term: Match   => eval(term)
       case term: Bundle  => eval(term)
-      case term: Expr =>
+      case term: Expr    =>
         term.exprInstance match {
           case e: EVarBody    => eval(e.value.v) >>= eval
           case e: EMethodBody => evalExprToPar(e) >>= eval
           case other          => BugFoundError(s"Undefined term: \n $other").raiseError[M, Unit]
         }
-      case other => BugFoundError(s"Undefined term: \n $other").raiseError[M, Unit]
+      case other         => BugFoundError(s"Undefined term: \n $other").raiseError[M, Unit]
     }
 
   /** Algorithm as follows:
@@ -275,46 +281,46 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: CostStateRef](
     * @param env An execution context
     *
     */
-  private def eval(send: Send)(
-      implicit env: Env[Par],
-      rand: Blake2b512Random
+  private def eval(send: Send)(implicit
+    env: Env[Par],
+    rand: Blake2b512Random,
   ): M[Unit] =
     for {
-      _        <- charge[M](SEND_EVAL_COST)
-      evalChan <- evalExpr(send.chan)
-      subChan  <- substituteAndCharge[Par, M](evalChan, depth = 0, env)
+      _         <- charge[M](SEND_EVAL_COST)
+      evalChan  <- evalExpr(send.chan)
+      subChan   <- substituteAndCharge[Par, M](evalChan, depth = 0, env)
       unbundled <- subChan.singleBundle() match {
-                    case Some(value) =>
-                      if (!value.writeFlag)
-                        ReduceError("Trying to send on non-writeable channel.").raiseError[M, Par]
-                      else value.body.pure[M]
-                    case None => subChan.pure[M]
-                  }
+                     case Some(value) =>
+                       if (!value.writeFlag)
+                         ReduceError("Trying to send on non-writeable channel.").raiseError[M, Par]
+                       else value.body.pure[M]
+                     case None        => subChan.pure[M]
+                   }
       data      <- send.data.toList.traverse(evalExpr)
       substData <- data.traverse(substituteAndCharge[Par, M](_, depth = 0, env))
       _         <- produce(unbundled, ListParWithRandom(substData, rand), send.persistent)
     } yield ()
 
-  private def eval(receive: Receive)(
-      implicit env: Env[Par],
-      rand: Blake2b512Random
+  private def eval(receive: Receive)(implicit
+    env: Env[Par],
+    rand: Blake2b512Random,
   ): M[Unit] =
     for {
-      _ <- charge[M](RECEIVE_EVAL_COST)
-      binds <- receive.binds.toList.traverse { rb =>
-                for {
-                  q <- unbundleReceive(rb)
-                  substPatterns <- rb.patterns.toList
-                                    .traverse(substituteAndCharge[Par, M](_, depth = 1, env))
-                } yield (BindPattern(substPatterns, rb.remainder, rb.freeCount), q)
-              }
+      _         <- charge[M](RECEIVE_EVAL_COST)
+      binds     <- receive.binds.toList.traverse { rb =>
+                     for {
+                       q             <- unbundleReceive(rb)
+                       substPatterns <- rb.patterns.toList
+                                          .traverse(substituteAndCharge[Par, M](_, depth = 1, env))
+                     } yield (BindPattern(substPatterns, rb.remainder, rb.freeCount), q)
+                   }
       // TODO: Allow for the environment to be stored with the body in the Tuplespace
       substBody <- substituteNoSortAndCharge[Par, M](
-                    receive.body,
-                    depth = 0,
-                    env.shift(receive.bindCount)
-                  )
-      _ <- consume(binds, ParWithRandom(substBody, rand), receive.persistent, receive.peek)
+                     receive.body,
+                     depth = 0,
+                     env.shift(receive.bindCount),
+                   )
+      _         <- consume(binds, ParWithRandom(substBody, rand), receive.persistent, receive.peek)
     } yield ()
 
   /**
@@ -328,24 +334,24 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: CostStateRef](
     *                  an exception.
     */
   private def eval(
-      valproc: Var
+    valproc: Var,
   )(implicit env: Env[Par]): M[Par] =
     charge[M](VAR_EVAL_COST) >> {
       valproc.varInstance match {
-        case BoundVar(level) =>
+        case BoundVar(level)   =>
           env.get(level).liftTo[M](ReduceError("Unbound variable: " + level + " in " + env.envMap))
-        case Wildcard(_) =>
+        case Wildcard(_)       =>
           ReduceError("Unbound variable: attempting to evaluate a pattern").raiseError[M, Par]
-        case FreeVar(_) =>
+        case FreeVar(_)        =>
           ReduceError("Unbound variable: attempting to evaluate a pattern").raiseError[M, Par]
         case VarInstance.Empty =>
           ReduceError("Impossible var instance EMPTY").raiseError[M, Par]
       }
     }
 
-  private def eval(mat: Match)(
-      implicit env: Env[Par],
-      rand: Blake2b512Random
+  private def eval(mat: Match)(implicit
+    env: Env[Par],
+    rand: Blake2b512Random,
   ): M[Unit] = {
 
     def addToEnv(env: Env[Par], freeMap: Map[Int, Par], freeCount: Int): Env[Par] =
@@ -353,24 +359,24 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: CostStateRef](
 
     def firstMatch(target: Par, cases: Seq[MatchCase])(implicit env: Env[Par]): M[Unit] = {
       def firstMatchM(
-          state: (Par, Seq[MatchCase])
+        state: (Par, Seq[MatchCase]),
       ): M[Either[(Par, Seq[MatchCase]), Unit]] = {
         val (target, cases) = state
         cases match {
-          case Nil => ().asRight[(Par, Seq[MatchCase])].pure[M]
+          case Nil                   => ().asRight[(Par, Seq[MatchCase])].pure[M]
           case singleCase +: caseRem =>
             for {
               pattern     <- substituteAndCharge[Par, M](singleCase.pattern, depth = 1, env)
               matchResult <- spatialMatchResult[M](target, pattern)
-              res <- matchResult match {
-                      case None =>
-                        (target, caseRem).asLeft[Unit].pure[M]
-                      case Some((freeMap, _)) =>
-                        eval(singleCase.source)(
-                          addToEnv(env, freeMap, singleCase.freeCount),
-                          implicitly
-                        ).map(_.asRight[(Par, Seq[MatchCase])])
-                    }
+              res         <- matchResult match {
+                               case None               =>
+                                 (target, caseRem).asLeft[Unit].pure[M]
+                               case Some((freeMap, _)) =>
+                                 eval(singleCase.source)(
+                                   addToEnv(env, freeMap, singleCase.freeCount),
+                                   implicitly,
+                                 ).map(_.asRight[(Par, Seq[MatchCase])])
+                             }
             } yield res
 
         }
@@ -382,8 +388,8 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: CostStateRef](
       _            <- charge[M](MATCH_EVAL_COST)
       evaledTarget <- evalExpr(mat.target)
       // TODO(kyle): Make the matcher accept an environment, instead of substituting it.
-      substTarget <- substituteAndCharge[Par, M](evaledTarget, depth = 0, env)
-      _           <- firstMatch(substTarget, mat.cases)
+      substTarget  <- substituteAndCharge[Par, M](evaledTarget, depth = 0, env)
+      _            <- firstMatch(substTarget, mat.cases)
     } yield ()
   }
 
@@ -393,7 +399,7 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: CostStateRef](
     */
   // TODO: Eliminate variable shadowing
   private def eval(
-      neu: New
+    neu: New,
   )(implicit env: Env[Par], rand: Blake2b512Random): M[Unit] = {
 
     def alloc(count: Int, urns: Seq[String]): M[Env[Par]] = {
@@ -404,7 +410,7 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: CostStateRef](
 
       def normalizerBugFound(urn: String) =
         BugFoundError(
-          s"No value set for `$urn`. This is a bug in the normalizer or on the path from it."
+          s"No value set for `$urn`. This is a bug in the normalizer or on the path from it.",
         )
 
       def addUrn(newEnv: Env[Par], urn: String): Either[InterpreterError, Env[Par]] =
@@ -439,66 +445,65 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: CostStateRef](
       evalSrc <- evalExpr(rb.source)
       subst   <- substituteAndCharge[Par, M](evalSrc, depth = 0, env)
       // Check if we try to read from bundled channel
-      unbndl <- subst.singleBundle() match {
-                 case Some(value) =>
-                   if (!value.readFlag)
-                     ReduceError("Trying to read from non-readable channel.").raiseError[M, Par]
-                   else value.body.pure[M]
-                 case None => subst.pure[M]
-               }
+      unbndl  <- subst.singleBundle() match {
+                   case Some(value) =>
+                     if (!value.readFlag)
+                       ReduceError("Trying to read from non-readable channel.").raiseError[M, Par]
+                     else value.body.pure[M]
+                   case None        => subst.pure[M]
+                 }
     } yield unbndl
 
   private def eval(
-      bundle: Bundle
+    bundle: Bundle,
   )(implicit env: Env[Par], rand: Blake2b512Random): M[Unit] =
     eval(bundle.body)
 
   private[rholang] def evalExprToPar(expr: Expr)(implicit env: Env[Par]): M[Par] =
     expr.exprInstance match {
-      case EVarBody(EVar(v)) =>
+      case EVarBody(EVar(v))                                     =>
         for {
           p       <- eval(v)
           evaledP <- evalExpr(p)
         } yield evaledP
-      case EMethodBody(EMethod(method, target, arguments, _, _)) => {
+      case EMethodBody(EMethod(method, target, arguments, _, _)) =>
         for {
           _            <- charge[M](METHOD_CALL_COST)
           evaledTarget <- evalExpr(target)
           evaledArgs   <- arguments.toList.traverse(evalExpr)
-          resultPar <- methodTable
-                        .get(method)
-                        .liftTo[M](ReduceError("Unimplemented method: " + method))
-                        .flatMap(_(evaledTarget, evaledArgs))
+          resultPar    <- methodTable
+                            .get(method)
+                            .liftTo[M](ReduceError("Unimplemented method: " + method))
+                            .flatMap(_(evaledTarget, evaledArgs))
         } yield resultPar
-      }
-      case _ => evalExprToExpr(expr).map(fromExpr(_)(identity))
+      case _                                                     => evalExprToExpr(expr).map(fromExpr(_)(identity))
     }
 
   private def evalExprToExpr(expr: Expr)(implicit env: Env[Par]): M[Expr] = {
     Sync[M].defer {
       def relop(
-          p1: Par,
-          p2: Par,
-          relopb: (Boolean, Boolean) => Boolean,
-          relopi: (Long, Long) => Boolean,
-          relopbi: (BigInt, BigInt) => Boolean,
-          relops: (String, String) => Boolean
+        p1: Par,
+        p2: Par,
+        relopb: (Boolean, Boolean) => Boolean,
+        relopi: (Long, Long) => Boolean,
+        relopbi: (BigInt, BigInt) => Boolean,
+        relops: (String, String) => Boolean,
       ): M[Expr] =
         for {
-          v1 <- evalSingleExpr(p1)
-          v2 <- evalSingleExpr(p2)
+          v1     <- evalSingleExpr(p1)
+          v2     <- evalSingleExpr(p2)
           result <- (v1.exprInstance, v2.exprInstance) match {
-                     case (GBool(b1), GBool(b2)) =>
-                       charge[M](COMPARISON_COST).as(GBool(relopb(b1, b2)))
-                     case (GInt(i1), GInt(i2)) =>
-                       charge[M](COMPARISON_COST).as(GBool(relopi(i1, i2)))
-                     case (GBigInt(bi1), GBigInt(bi2)) =>
-                       charge[M](bigIntComparison(bi1, bi2)).as(GBool(relopbi(bi1, bi2)))
-                     case (GString(s1), GString(s2)) =>
-                       charge[M](COMPARISON_COST).as(GBool(relops(s1, s2)))
-                     case _ =>
-                       ReduceError("Unexpected compare: " + v1 + " vs. " + v2).raiseError[M, GBool]
-                   }
+                      case (GBool(b1), GBool(b2))       =>
+                        charge[M](COMPARISON_COST).as(GBool(relopb(b1, b2)))
+                      case (GInt(i1), GInt(i2))         =>
+                        charge[M](COMPARISON_COST).as(GBool(relopi(i1, i2)))
+                      case (GBigInt(bi1), GBigInt(bi2)) =>
+                        charge[M](bigIntComparison(bi1, bi2)).as(GBool(relopbi(bi1, bi2)))
+                      case (GString(s1), GString(s2))   =>
+                        charge[M](COMPARISON_COST).as(GBool(relops(s1, s2)))
+                      case _                            =>
+                        ReduceError("Unexpected compare: " + v1 + " vs. " + v2).raiseError[M, GBool]
+                    }
         } yield result
 
       expr.exprInstance match {
@@ -512,120 +517,120 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: CostStateRef](
 
         case ENegBody(ENeg(p)) =>
           for {
-            v <- evalSingleExpr(p)
+            v      <- evalSingleExpr(p)
             result <- v.exprInstance match {
-                       case GInt(hs) => Expr(GInt(-hs)).pure[M]
-                       case GBigInt(hs) =>
-                         for {
-                           r <- Sync[M].delay(-hs)
-                           _ <- charge[M](bigIntNegation(r))
-                         } yield Expr(GBigInt(r))
-                       case other => OperatorNotDefined("Negation", other.typ).raiseError[M, Expr]
-                     }
+                        case GInt(hs)    => Expr(GInt(-hs)).pure[M]
+                        case GBigInt(hs) =>
+                          for {
+                            r <- Sync[M].delay(-hs)
+                            _ <- charge[M](bigIntNegation(r))
+                          } yield Expr(GBigInt(r))
+                        case other       => OperatorNotDefined("Negation", other.typ).raiseError[M, Expr]
+                      }
           } yield result
 
         case EMultBody(EMult(p1, p2)) =>
           for {
-            v1 <- evalSingleExpr(p1)
-            v2 <- evalSingleExpr(p2)
+            v1     <- evalSingleExpr(p1)
+            v2     <- evalSingleExpr(p2)
             result <- (v1.exprInstance, v2.exprInstance) match {
-                       case (GInt(lhs), GInt(rhs)) =>
-                         charge[M](MULTIPLICATION_COST).as(Expr(GInt(lhs * rhs)))
-                       case (GBigInt(lhs), GBigInt(rhs)) =>
-                         charge[M](bigIntMultiplication(lhs, rhs)).as(Expr(GBigInt(lhs * rhs)))
-                       case (_: GInt, other) =>
-                         OperatorExpectedError("*", "Int", other.typ).raiseError[M, Expr]
-                       case (_: GBigInt, other) =>
-                         OperatorExpectedError("*", "BigInt", other.typ).raiseError[M, Expr]
-                       case (other, _) => OperatorNotDefined("*", other.typ).raiseError[M, Expr]
-                     }
+                        case (GInt(lhs), GInt(rhs))       =>
+                          charge[M](MULTIPLICATION_COST).as(Expr(GInt(lhs * rhs)))
+                        case (GBigInt(lhs), GBigInt(rhs)) =>
+                          charge[M](bigIntMultiplication(lhs, rhs)).as(Expr(GBigInt(lhs * rhs)))
+                        case (_: GInt, other)             =>
+                          OperatorExpectedError("*", "Int", other.typ).raiseError[M, Expr]
+                        case (_: GBigInt, other)          =>
+                          OperatorExpectedError("*", "BigInt", other.typ).raiseError[M, Expr]
+                        case (other, _)                   => OperatorNotDefined("*", other.typ).raiseError[M, Expr]
+                      }
           } yield result
 
         case EDivBody(EDiv(p1, p2)) =>
           for {
-            v1 <- evalSingleExpr(p1)
-            v2 <- evalSingleExpr(p2)
+            v1     <- evalSingleExpr(p1)
+            v2     <- evalSingleExpr(p2)
             result <- (v1.exprInstance, v2.exprInstance) match {
-                       case (GInt(lhs), GInt(rhs)) =>
-                         charge[M](DIVISION_COST).as(Expr(GInt(lhs / rhs)))
-                       case (GBigInt(lhs), GBigInt(rhs)) =>
-                         charge[M](bigIntDivision(lhs, rhs)).as(Expr(GBigInt(lhs / rhs)))
-                       case (_: GInt, other) =>
-                         OperatorExpectedError("/", "Int", other.typ).raiseError[M, Expr]
-                       case (_: GBigInt, other) =>
-                         OperatorExpectedError("/", "BigInt", other.typ).raiseError[M, Expr]
-                       case (other, _) => OperatorNotDefined("/", other.typ).raiseError[M, Expr]
-                     }
+                        case (GInt(lhs), GInt(rhs))       =>
+                          charge[M](DIVISION_COST).as(Expr(GInt(lhs / rhs)))
+                        case (GBigInt(lhs), GBigInt(rhs)) =>
+                          charge[M](bigIntDivision(lhs, rhs)).as(Expr(GBigInt(lhs / rhs)))
+                        case (_: GInt, other)             =>
+                          OperatorExpectedError("/", "Int", other.typ).raiseError[M, Expr]
+                        case (_: GBigInt, other)          =>
+                          OperatorExpectedError("/", "BigInt", other.typ).raiseError[M, Expr]
+                        case (other, _)                   => OperatorNotDefined("/", other.typ).raiseError[M, Expr]
+                      }
           } yield result
 
         case EModBody(EMod(p1, p2)) =>
           for {
-            v1 <- evalSingleExpr(p1)
-            v2 <- evalSingleExpr(p2)
+            v1     <- evalSingleExpr(p1)
+            v2     <- evalSingleExpr(p2)
             result <- (v1.exprInstance, v2.exprInstance) match {
-                       case (GInt(lhs), GInt(rhs)) =>
-                         charge[M](MODULO_COST).as(Expr(GInt(lhs % rhs)))
-                       case (GBigInt(lhs), GBigInt(rhs)) =>
-                         charge[M](bigIntModulo(lhs, rhs)).as(Expr(GBigInt(lhs % rhs)))
-                       case (_: GInt, other) =>
-                         OperatorExpectedError("%", "Int", other.typ).raiseError[M, Expr]
-                       case (_: GBigInt, other) =>
-                         OperatorExpectedError("%", "BigInt", other.typ).raiseError[M, Expr]
-                       case (other, _) => OperatorNotDefined("%", other.typ).raiseError[M, Expr]
-                     }
+                        case (GInt(lhs), GInt(rhs))       =>
+                          charge[M](MODULO_COST).as(Expr(GInt(lhs % rhs)))
+                        case (GBigInt(lhs), GBigInt(rhs)) =>
+                          charge[M](bigIntModulo(lhs, rhs)).as(Expr(GBigInt(lhs % rhs)))
+                        case (_: GInt, other)             =>
+                          OperatorExpectedError("%", "Int", other.typ).raiseError[M, Expr]
+                        case (_: GBigInt, other)          =>
+                          OperatorExpectedError("%", "BigInt", other.typ).raiseError[M, Expr]
+                        case (other, _)                   => OperatorNotDefined("%", other.typ).raiseError[M, Expr]
+                      }
           } yield result
 
         case EPlusBody(EPlus(p1, p2)) =>
           for {
-            v1 <- evalSingleExpr(p1)
-            v2 <- evalSingleExpr(p2)
+            v1     <- evalSingleExpr(p1)
+            v2     <- evalSingleExpr(p2)
             result <- (v1.exprInstance, v2.exprInstance) match {
-                       case (GInt(lhs), GInt(rhs)) =>
-                         charge[M](SUM_COST).as(Expr(GInt(lhs + rhs)))
-                       case (GBigInt(lhs), GBigInt(rhs)) =>
-                         charge[M](bigIntSum(lhs, rhs)).as(Expr(GBigInt(lhs + rhs)))
-                       case (lhs: ESetBody, rhs) =>
-                         for {
-                           _         <- charge[M](OP_CALL_COST)
-                           resultPar <- add(lhs, List[Par](rhs))
-                           resultExp <- evalSingleExpr(resultPar)
-                         } yield resultExp
-                       case (_: GInt, other) =>
-                         OperatorExpectedError("+", "Int", other.typ).raiseError[M, Expr]
-                       case (_: GBigInt, other) =>
-                         OperatorExpectedError("+", "BigInt", other.typ).raiseError[M, Expr]
-                       case (other, _) => OperatorNotDefined("+", other.typ).raiseError[M, Expr]
-                     }
+                        case (GInt(lhs), GInt(rhs))       =>
+                          charge[M](SUM_COST).as(Expr(GInt(lhs + rhs)))
+                        case (GBigInt(lhs), GBigInt(rhs)) =>
+                          charge[M](bigIntSum(lhs, rhs)).as(Expr(GBigInt(lhs + rhs)))
+                        case (lhs: ESetBody, rhs)         =>
+                          for {
+                            _         <- charge[M](OP_CALL_COST)
+                            resultPar <- add(lhs, List[Par](rhs))
+                            resultExp <- evalSingleExpr(resultPar)
+                          } yield resultExp
+                        case (_: GInt, other)             =>
+                          OperatorExpectedError("+", "Int", other.typ).raiseError[M, Expr]
+                        case (_: GBigInt, other)          =>
+                          OperatorExpectedError("+", "BigInt", other.typ).raiseError[M, Expr]
+                        case (other, _)                   => OperatorNotDefined("+", other.typ).raiseError[M, Expr]
+                      }
           } yield result
 
         case EMinusBody(EMinus(p1, p2)) =>
           for {
-            v1 <- evalSingleExpr(p1)
-            v2 <- evalSingleExpr(p2)
+            v1     <- evalSingleExpr(p1)
+            v2     <- evalSingleExpr(p2)
             result <- (v1.exprInstance, v2.exprInstance) match {
-                       case (GInt(lhs), GInt(rhs)) =>
-                         charge[M](SUBTRACTION_COST).as(Expr(GInt(lhs - rhs)))
-                       case (GBigInt(lhs), GBigInt(rhs)) =>
-                         charge[M](bigIntSubtraction(lhs, rhs)).as(Expr(GBigInt(lhs - rhs)))
-                       case (lhs: EMapBody, rhs) =>
-                         for {
-                           _         <- charge[M](OP_CALL_COST)
-                           resultPar <- delete(lhs, List[Par](rhs))
-                           resultExp <- evalSingleExpr(resultPar)
-                         } yield resultExp
-                       case (lhs: ESetBody, rhs) =>
-                         for {
-                           _         <- charge[M](OP_CALL_COST)
-                           resultPar <- delete(lhs, List[Par](rhs))
-                           resultExp <- evalSingleExpr(resultPar)
-                         } yield resultExp
-                       case (_: GInt, other) =>
-                         OperatorExpectedError("-", "Int", other.typ).raiseError[M, Expr]
-                       case (_: GBigInt, other) =>
-                         OperatorExpectedError("-", "BigInt", other.typ).raiseError[M, Expr]
-                       case (other, _) =>
-                         OperatorNotDefined("-", other.typ).raiseError[M, Expr]
-                     }
+                        case (GInt(lhs), GInt(rhs))       =>
+                          charge[M](SUBTRACTION_COST).as(Expr(GInt(lhs - rhs)))
+                        case (GBigInt(lhs), GBigInt(rhs)) =>
+                          charge[M](bigIntSubtraction(lhs, rhs)).as(Expr(GBigInt(lhs - rhs)))
+                        case (lhs: EMapBody, rhs)         =>
+                          for {
+                            _         <- charge[M](OP_CALL_COST)
+                            resultPar <- delete(lhs, List[Par](rhs))
+                            resultExp <- evalSingleExpr(resultPar)
+                          } yield resultExp
+                        case (lhs: ESetBody, rhs)         =>
+                          for {
+                            _         <- charge[M](OP_CALL_COST)
+                            resultPar <- delete(lhs, List[Par](rhs))
+                            resultExp <- evalSingleExpr(resultPar)
+                          } yield resultExp
+                        case (_: GInt, other)             =>
+                          OperatorExpectedError("-", "Int", other.typ).raiseError[M, Expr]
+                        case (_: GBigInt, other)          =>
+                          OperatorExpectedError("-", "BigInt", other.typ).raiseError[M, Expr]
+                        case (other, _)                   =>
+                          OperatorNotDefined("-", other.typ).raiseError[M, Expr]
+                      }
           } yield result
 
         case ELtBody(ELt(p1, p2)) => relop(p1, p2, _ < _, _ < _, _ < _, _ < _)
@@ -638,8 +643,8 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: CostStateRef](
 
         case EEqBody(EEq(p1, p2)) =>
           for {
-            v1 <- evalExpr(p1)
-            v2 <- evalExpr(p2)
+            v1  <- evalExpr(p1)
+            v2  <- evalExpr(p2)
             // TODO: build an equality operator that takes in an environment.
             sv1 <- substituteAndCharge[Par, M](v1, depth = 0, env)
             sv2 <- substituteAndCharge[Par, M](v2, depth = 0, env)
@@ -673,18 +678,18 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: CostStateRef](
           for {
             b1 <- evalToBool(p1)
             b2 <- if (b1) {
-                   evalToBool(p2)
-                 } else false.pure
-            _ <- charge[M](BOOLEAN_AND_COST)
+                    evalToBool(p2)
+                  } else false.pure
+            _  <- charge[M](BOOLEAN_AND_COST)
           } yield GBool(b1 && b2)
 
         case EShortOrBody(EShortOr(p1, p2)) =>
           for {
             b1 <- evalToBool(p1)
             b2 <- if (b1) {
-                   true.pure
-                 } else evalToBool(p2)
-            _ <- charge[M](BOOLEAN_OR_COST)
+                    true.pure
+                  } else evalToBool(p2)
+            _  <- charge[M](BOOLEAN_OR_COST)
           } yield GBool(b1 || b2)
 
         case EMatchesBody(EMatches(target, pattern)) =>
@@ -696,138 +701,134 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: CostStateRef](
           } yield GBool(matchResult.isDefined)
 
         case EPercentPercentBody(EPercentPercent(p1, p2)) =>
-          def evalToStringPair(keyExpr: Expr, valueExpr: Expr): M[(String, String)] =
+          def evalToStringPair(keyExpr: Expr, valueExpr: Expr): M[(String, String)]      =
             (keyExpr.exprInstance, valueExpr.exprInstance) match {
               case (GString(keyString), GString(valueString)) =>
                 (keyString -> valueString).pure[M]
-              case (GString(keyString), GInt(valueInt)) =>
+              case (GString(keyString), GInt(valueInt))       =>
                 (keyString -> valueInt.toString).pure[M]
               case (GString(keyString), GBigInt(valueBigInt)) =>
                 (keyString -> valueBigInt.toString).pure[M]
-              case (GString(keyString), GBool(valueBool)) =>
+              case (GString(keyString), GBool(valueBool))     =>
                 (keyString -> valueBool.toString).pure[M]
-              case (GString(keyString), GUri(uri)) =>
+              case (GString(keyString), GUri(uri))            =>
                 (keyString -> uri).pure[M]
               // TODO: Add cases for other ground terms as well? Maybe it would be better
               // to implement cats.Show for all ground terms.
-              case (_: GString, value) =>
+              case (_: GString, value)                        =>
                 ReduceError(s"Error: interpolation doesn't support ${value.typ}")
                   .raiseError[M, (String, String)]
-              case _ =>
+              case _                                          =>
                 ReduceError("Error: interpolation Map should only contain String keys")
                   .raiseError[M, (String, String)]
             }
           @SuppressWarnings(
-            Array("org.wartremover.warts.Var", "org.wartremover.warts.NonUnitStatements")
+            Array("org.wartremover.warts.Var", "org.wartremover.warts.NonUnitStatements"),
           )
           // TODO consider replacing while loop with tailrec recursion
           def interpolate(string: String, keyValuePairs: List[(String, String)]): String = {
             val result  = new StringBuilder()
             var current = string
-            while (current.nonEmpty) {
-              keyValuePairs.find {
-                case (k, _) => current.startsWith("${" + k + "}")
+            while (current.nonEmpty)
+              keyValuePairs.find { case (k, _) =>
+                current.startsWith("${" + k + "}")
               } match {
                 case Some((k, v)) =>
                   result ++= v
                   current = current.drop(k.length + 3)
-                case None =>
+                case None         =>
                   result += current.head
                   current = current.tail
               }
-            }
             result.toString
           }
           for {
-            _  <- charge[M](OP_CALL_COST)
-            v1 <- evalSingleExpr(p1)
-            v2 <- evalSingleExpr(p2)
+            _      <- charge[M](OP_CALL_COST)
+            v1     <- evalSingleExpr(p1)
+            v2     <- evalSingleExpr(p2)
             result <- (v1.exprInstance, v2.exprInstance) match {
-                       case (GString(lhs), EMapBody(ParMap(rhs, _, _, _))) =>
-                         if (lhs.nonEmpty || rhs.nonEmpty) {
-                           for {
-                             result <- rhs.toList
-                                        .traverse {
-                                          case (k, v) =>
+                        case (GString(lhs), EMapBody(ParMap(rhs, _, _, _))) =>
+                          if (lhs.nonEmpty || rhs.nonEmpty) {
+                            for {
+                              result <- rhs.toList
+                                          .traverse { case (k, v) =>
                                             for {
                                               keyExpr   <- evalSingleExpr(k)
                                               valueExpr <- evalSingleExpr(v)
                                               result    <- evalToStringPair(keyExpr, valueExpr)
                                             } yield result
-                                        }
-                                        .map(
-                                          keyValuePairs => GString(interpolate(lhs, keyValuePairs))
-                                        )
-                             _ <- charge[M](interpolateCost(lhs.length, rhs.size))
-                           } yield result
-                         } else GString(lhs).pure[M]
-                       case (_: GString, other) =>
-                         OperatorExpectedError("%%", "Map", other.typ).raiseError[M, GString]
-                       case (other, _) =>
-                         OperatorNotDefined("%%", other.typ).raiseError[M, GString]
-                     }
+                                          }
+                                          .map(keyValuePairs => GString(interpolate(lhs, keyValuePairs)))
+                              _      <- charge[M](interpolateCost(lhs.length, rhs.size))
+                            } yield result
+                          } else GString(lhs).pure[M]
+                        case (_: GString, other)                            =>
+                          OperatorExpectedError("%%", "Map", other.typ).raiseError[M, GString]
+                        case (other, _)                                     =>
+                          OperatorNotDefined("%%", other.typ).raiseError[M, GString]
+                      }
           } yield result
 
         case EPlusPlusBody(EPlusPlus(p1, p2)) =>
           for {
-            _  <- charge[M](OP_CALL_COST)
-            v1 <- evalSingleExpr(p1)
-            v2 <- evalSingleExpr(p2)
+            _      <- charge[M](OP_CALL_COST)
+            v1     <- evalSingleExpr(p1)
+            v2     <- evalSingleExpr(p2)
             result <- (v1.exprInstance, v2.exprInstance) match {
-                       case (GString(lhs), GString(rhs)) =>
-                         charge[M](stringAppendCost(lhs.length, rhs.length)) >>
-                           Expr(GString(lhs + rhs)).pure[M]
-                       case (GByteArray(lhs), GByteArray(rhs)) =>
-                         charge[M](byteArrayAppendCost(lhs)) >>
-                           Expr(GByteArray(lhs.concat(rhs))).pure[M]
-                       case (EListBody(lhs), EListBody(rhs)) =>
-                         charge[M](listAppendCost(rhs.ps.toVector)) >>
-                           Expr(
-                             EListBody(
-                               EList(
-                                 lhs.ps ++ rhs.ps,
-                                 lhs.locallyFree union rhs.locallyFree,
-                                 lhs.connectiveUsed || rhs.connectiveUsed
-                               )
-                             )
-                           ).pure[M]
-                       case (lhs: EMapBody, rhs: EMapBody) =>
-                         for {
-                           resultPar <- union(lhs, List[Par](rhs))
-                           resultExp <- evalSingleExpr(resultPar)
-                         } yield resultExp
-                       case (lhs: ESetBody, rhs: ESetBody) =>
-                         for {
-                           resultPar <- union(lhs, List[Par](rhs))
-                           resultExp <- evalSingleExpr(resultPar)
-                         } yield resultExp
-                       case (_: GString, other) =>
-                         OperatorExpectedError("++", "String", other.typ).raiseError[M, Expr]
-                       case (_: EListBody, other) =>
-                         OperatorExpectedError("++", "List", other.typ).raiseError[M, Expr]
-                       case (_: EMapBody, other) =>
-                         OperatorExpectedError("++", "Map", other.typ).raiseError[M, Expr]
-                       case (_: ESetBody, other) =>
-                         OperatorExpectedError("++", "Set", other.typ).raiseError[M, Expr]
-                       case (other, _) => OperatorNotDefined("++", other.typ).raiseError[M, Expr]
-                     }
+                        case (GString(lhs), GString(rhs))       =>
+                          charge[M](stringAppendCost(lhs.length, rhs.length)) >>
+                            Expr(GString(lhs + rhs)).pure[M]
+                        case (GByteArray(lhs), GByteArray(rhs)) =>
+                          charge[M](byteArrayAppendCost(lhs)) >>
+                            Expr(GByteArray(lhs.concat(rhs))).pure[M]
+                        case (EListBody(lhs), EListBody(rhs))   =>
+                          charge[M](listAppendCost(rhs.ps.toVector)) >>
+                            Expr(
+                              EListBody(
+                                EList(
+                                  lhs.ps ++ rhs.ps,
+                                  lhs.locallyFree union rhs.locallyFree,
+                                  lhs.connectiveUsed || rhs.connectiveUsed,
+                                ),
+                              ),
+                            ).pure[M]
+                        case (lhs: EMapBody, rhs: EMapBody)     =>
+                          for {
+                            resultPar <- union(lhs, List[Par](rhs))
+                            resultExp <- evalSingleExpr(resultPar)
+                          } yield resultExp
+                        case (lhs: ESetBody, rhs: ESetBody)     =>
+                          for {
+                            resultPar <- union(lhs, List[Par](rhs))
+                            resultExp <- evalSingleExpr(resultPar)
+                          } yield resultExp
+                        case (_: GString, other)                =>
+                          OperatorExpectedError("++", "String", other.typ).raiseError[M, Expr]
+                        case (_: EListBody, other)              =>
+                          OperatorExpectedError("++", "List", other.typ).raiseError[M, Expr]
+                        case (_: EMapBody, other)               =>
+                          OperatorExpectedError("++", "Map", other.typ).raiseError[M, Expr]
+                        case (_: ESetBody, other)               =>
+                          OperatorExpectedError("++", "Set", other.typ).raiseError[M, Expr]
+                        case (other, _)                         => OperatorNotDefined("++", other.typ).raiseError[M, Expr]
+                      }
           } yield result
 
         case EMinusMinusBody(EMinusMinus(p1, p2)) =>
           for {
-            _  <- charge[M](OP_CALL_COST)
-            v1 <- evalSingleExpr(p1)
-            v2 <- evalSingleExpr(p2)
+            _      <- charge[M](OP_CALL_COST)
+            v1     <- evalSingleExpr(p1)
+            v2     <- evalSingleExpr(p2)
             result <- (v1.exprInstance, v2.exprInstance) match {
-                       case (lhs: ESetBody, rhs: ESetBody) =>
-                         for {
-                           resultPar <- diff(lhs, List[Par](rhs))
-                           resultExp <- evalSingleExpr(resultPar)
-                         } yield resultExp
-                       case (_: ESetBody, other) =>
-                         OperatorExpectedError("--", "Set", other.typ).raiseError[M, Expr]
-                       case (other, _) => OperatorNotDefined("--", other.typ).raiseError[M, Expr]
-                     }
+                        case (lhs: ESetBody, rhs: ESetBody) =>
+                          for {
+                            resultPar <- diff(lhs, List[Par](rhs))
+                            resultExp <- evalSingleExpr(resultPar)
+                          } yield resultExp
+                        case (_: ESetBody, other)           =>
+                          OperatorExpectedError("--", "Set", other.typ).raiseError[M, Expr]
+                        case (other, _)                     => OperatorNotDefined("--", other.typ).raiseError[M, Expr]
+                      }
           } yield result
 
         case EVarBody(EVar(v)) =>
@@ -838,31 +839,30 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: CostStateRef](
 
         case EListBody(el) =>
           for {
-            evaledPs  <- el.ps.toList.traverse(evalExpr)
+            evaledPs <- el.ps.toList.traverse(evalExpr)
             updatedPs = evaledPs.map(updateLocallyFree)
           } yield updateLocallyFree(EList(updatedPs, el.locallyFree, el.connectiveUsed))
 
         case ETupleBody(el) =>
           for {
-            evaledPs  <- el.ps.toList.traverse(evalExpr)
+            evaledPs <- el.ps.toList.traverse(evalExpr)
             updatedPs = evaledPs.map(updateLocallyFree)
           } yield updateLocallyFree(ETuple(updatedPs, el.locallyFree, el.connectiveUsed))
 
         case ESetBody(set) =>
           for {
-            evaledPs  <- set.ps.sortedPars.traverse(evalExpr)
+            evaledPs <- set.ps.sortedPars.traverse(evalExpr)
             updatedPs = evaledPs.map(updateLocallyFree)
           } yield set.copy(ps = SortedParHashSet(updatedPs))
 
         case EMapBody(map) =>
           for {
-            evaledPs <- map.ps.sortedList.traverse {
-                         case (key, value) =>
-                           for {
-                             eKey   <- evalExpr(key).map(updateLocallyFree)
-                             eValue <- evalExpr(value).map(updateLocallyFree)
-                           } yield (eKey, eValue)
-                       }
+            evaledPs <- map.ps.sortedList.traverse { case (key, value) =>
+                          for {
+                            eKey   <- evalExpr(key).map(updateLocallyFree)
+                            eValue <- evalExpr(value).map(updateLocallyFree)
+                          } yield (eKey, eValue)
+                        }
           } yield map.copy(ps = SortedParMap(evaledPs))
 
         case EMethodBody(EMethod(method, target, arguments, _, _)) =>
@@ -870,20 +870,20 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: CostStateRef](
             _            <- charge[M](METHOD_CALL_COST)
             evaledTarget <- evalExpr(target)
             evaledArgs   <- arguments.toList.traverse(evalExpr)
-            resultPar <- methodTable
-                          .get(method)
-                          .liftTo[M](ReduceError("Unimplemented method: " + method))
-                          .flatMap(_(evaledTarget, evaledArgs))
-            resultExpr <- evalSingleExpr(resultPar)
+            resultPar    <- methodTable
+                              .get(method)
+                              .liftTo[M](ReduceError("Unimplemented method: " + method))
+                              .flatMap(_(evaledTarget, evaledArgs))
+            resultExpr   <- evalSingleExpr(resultPar)
           } yield resultExpr
-        case _ => ReduceError("Unimplemented expression: " + expr).raiseError[M, Expr]
+        case _                                                     => ReduceError("Unimplemented expression: " + expr).raiseError[M, Expr]
       }
     }
   }
 
-  private abstract class Method() {
-    def apply(p: Par, args: Seq[Par])(
-        implicit env: Env[Par]
+  abstract private class Method() {
+    def apply(p: Par, args: Seq[Par])(implicit
+      env: Env[Par],
     ): M[Par]
   }
 
@@ -903,20 +903,20 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: CostStateRef](
           nth    <- restrictToInt(nthRaw)
           v      <- evalSingleExpr(p)
           result <- v.exprInstance match {
-                     case EListBody(EList(ps, _, _, _)) =>
-                       Sync[M].fromEither(localNth(ps, nth))
-                     case ETupleBody(ETuple(ps, _, _)) =>
-                       Sync[M].fromEither(localNth(ps, nth))
-                     case GByteArray(bs) =>
-                       Sync[M].fromEither(if (0 <= nth && nth < bs.size) {
-                         val b      = bs.byteAt(nth) & 0xff // convert to unsigned
-                         val p: Par = Expr(GInt(b.toLong))
-                         p.asRight[ReduceError]
-                       } else ReduceError("Error: index out of bound: " + nth).asLeft[Par])
-                     case _ =>
-                       ReduceError("Error: nth applied to something that wasn't a list or tuple.")
-                         .raiseError[M, Par]
-                   }
+                      case EListBody(EList(ps, _, _, _)) =>
+                        Sync[M].fromEither(localNth(ps, nth))
+                      case ETupleBody(ETuple(ps, _, _))  =>
+                        Sync[M].fromEither(localNth(ps, nth))
+                      case GByteArray(bs)                =>
+                        Sync[M].fromEither(if (0 <= nth && nth < bs.size) {
+                          val b      = bs.byteAt(nth) & 0xff // convert to unsigned
+                          val p: Par = Expr(GInt(b.toLong))
+                          p.asRight[ReduceError]
+                        } else ReduceError("Error: index out of bound: " + nth).asLeft[Par])
+                      case _                             =>
+                        ReduceError("Error: nth applied to something that wasn't a list or tuple.")
+                          .raiseError[M, Par]
+                    }
         } yield result
       }
   }
@@ -961,13 +961,12 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: CostStateRef](
 
         case GString(str) =>
           for {
-            _ <- charge[M](toIntCost(str))
-            longVal <- Sync[M].delay(str.toLong).adaptError {
-                        case _: Throwable =>
-                          ReduceError(
-                            s"""Method toInt(): input string "$str" cannot be converted to Int"""
-                          )
-                      }
+            _       <- charge[M](toIntCost(str))
+            longVal <- Sync[M].delay(str.toLong).adaptError { case _: Throwable =>
+                         ReduceError(
+                           s"""Method toInt(): input string "$str" cannot be converted to Int""",
+                         )
+                       }
           } yield GInt(longVal)
 
         case other => MethodNotDefined("toInt", other.typ).raiseError[M, GInt]
@@ -975,9 +974,9 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: CostStateRef](
 
     override def apply(p: Par, args: Seq[Par])(implicit env: Env[Par]): M[Par] =
       for {
-        _ <- MethodArgumentNumberMismatch("toInt", 0, args.length)
-              .raiseError[M, Unit]
-              .whenA(args.nonEmpty)
+        _        <- MethodArgumentNumberMismatch("toInt", 0, args.length)
+                      .raiseError[M, Unit]
+                      .whenA(args.nonEmpty)
         baseExpr <- evalSingleExpr(p)
         r        <- createGInt(baseExpr)
       } yield r
@@ -995,13 +994,12 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: CostStateRef](
 
         case GString(str) =>
           for {
-            _ <- charge[M](toBigIntCost(str))
-            bigInt <- Sync[M].delay(BigInt(str)).adaptError {
-                       case _: Throwable =>
-                         ReduceError(
-                           s"""Method toBigInt(): input string "$str" cannot be converted to BigInt"""
-                         )
-                     }
+            _      <- charge[M](toBigIntCost(str))
+            bigInt <- Sync[M].delay(BigInt(str)).adaptError { case _: Throwable =>
+                        ReduceError(
+                          s"""Method toBigInt(): input string "$str" cannot be converted to BigInt""",
+                        )
+                      }
           } yield GBigInt(bigInt)
 
         case other => MethodNotDefined("toBigInt", other.typ).raiseError[M, GBigInt]
@@ -1009,9 +1007,9 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: CostStateRef](
 
     override def apply(p: Par, args: Seq[Par])(implicit env: Env[Par]): M[Par] =
       for {
-        _ <- MethodArgumentNumberMismatch("toBigInt", 0, args.length)
-              .raiseError[M, Unit]
-              .whenA(args.nonEmpty)
+        _        <- MethodArgumentNumberMismatch("toBigInt", 0, args.length)
+                      .raiseError[M, Unit]
+                      .whenA(args.nonEmpty)
         baseExpr <- evalSingleExpr(p)
         r        <- createGBigInt(baseExpr)
       } yield r
@@ -1026,19 +1024,19 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: CostStateRef](
         p.singleExpr match {
           case Some(Expr(GString(encoded))) =>
             for {
-              _ <- charge[M](hexToBytesCost(encoded))
+              _   <- charge[M](hexToBytesCost(encoded))
               res <- Sync[M]
-                      .delay(encoded.unsafeHexToByteString)
-                      .handleErrorWith { ex =>
-                        ReduceError(
-                          s"Error: exception was thrown when decoding input string to hexadecimal: ${ex.getMessage}"
-                        ).raiseError[M, ByteString]
-                      }
-                      .map(ba => Expr(GByteArray(ba)): Par)
+                       .delay(encoded.unsafeHexToByteString)
+                       .handleErrorWith { ex =>
+                         ReduceError(
+                           s"Error: exception was thrown when decoding input string to hexadecimal: ${ex.getMessage}",
+                         ).raiseError[M, ByteString]
+                       }
+                       .map(ba => Expr(GByteArray(ba)): Par)
             } yield res
-          case Some(Expr(other)) =>
+          case Some(Expr(other))            =>
             MethodNotDefined("hexToBytes", other.typ).raiseError[M, Par]
-          case None =>
+          case None                         =>
             ReduceError("Error: Method can only be called on singular expressions.")
               .raiseError[M, Par]
         }
@@ -1054,19 +1052,19 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: CostStateRef](
         p.singleExpr match {
           case Some(Expr(GByteArray(bytes))) =>
             for {
-              _ <- charge[M](bytesToHexCost(bytes.toByteArray))
+              _   <- charge[M](bytesToHexCost(bytes.toByteArray))
               res <- Sync[M]
-                      .delay(Base16.encode(bytes.toByteArray))
-                      .handleErrorWith { ex =>
-                        ReduceError(
-                          s"Error: exception was thrown when encoding input byte array to hexadecimal string: ${ex.getMessage}"
-                        ).raiseError[M, String]
-                      }
-                      .map(str => Expr(GString(str)): Par)
+                       .delay(Base16.encode(bytes.toByteArray))
+                       .handleErrorWith { ex =>
+                         ReduceError(
+                           s"Error: exception was thrown when encoding input byte array to hexadecimal string: ${ex.getMessage}",
+                         ).raiseError[M, String]
+                       }
+                       .map(str => Expr(GString(str)): Par)
             } yield res
-          case Some(Expr(other)) =>
+          case Some(Expr(other))             =>
             MethodNotDefined("bytesToHex", other.typ).raiseError[M, Par]
-          case None =>
+          case None                          =>
             ReduceError("Error: Method can only be called on singular expressions.")
               .raiseError[M, Par]
         }
@@ -1083,9 +1081,9 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: CostStateRef](
           case Some(Expr(GString(utf8string))) =>
             charge[M](hexToBytesCost(utf8string)) >>
               (GByteArray(ByteString.copyFrom(utf8string.getBytes("UTF-8"))): Par).pure[M]
-          case Some(Expr(other)) =>
+          case Some(Expr(other))               =>
             MethodNotDefined("toUtf8Bytes", other.typ).raiseError[M, Par]
-          case None =>
+          case None                            =>
             ReduceError("Error: Method can only be called on singular expressions.")
               .raiseError[M, Par]
         }
@@ -1100,8 +1098,8 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: CostStateRef](
     def union(baseExpr: Expr, otherExpr: Expr): M[Expr] =
       (baseExpr.exprInstance, otherExpr.exprInstance) match {
         case (
-            ESetBody(base @ ParSet(basePs, _, _, _)),
-            ESetBody(other @ ParSet(otherPs, _, _, _))
+              ESetBody(base @ ParSet(basePs, _, _, _)),
+              ESetBody(other @ ParSet(otherPs, _, _, _)),
             ) =>
           charge[M](unionCost(otherPs.size)) >>
             Expr(
@@ -1110,13 +1108,13 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: CostStateRef](
                   basePs.union(otherPs.sortedPars.toSet),
                   base.connectiveUsed || other.connectiveUsed,
                   locallyFreeUnion(base.locallyFree, other.locallyFree),
-                  None
-                )
-              )
+                  None,
+                ),
+              ),
             ).pure[M]
         case (
-            EMapBody(base @ ParMap(baseMap, _, _, _)),
-            EMapBody(other @ ParMap(otherMap, _, _, _))
+              EMapBody(base @ ParMap(baseMap, _, _, _)),
+              EMapBody(other @ ParMap(otherMap, _, _, _)),
             ) =>
           charge[M](unionCost(otherMap.size)) >>
             Expr(
@@ -1125,9 +1123,9 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: CostStateRef](
                   (baseMap ++ otherMap).toSeq,
                   base.connectiveUsed || other.connectiveUsed,
                   locallyFreeUnion(base.locallyFree, other.locallyFree),
-                  None
-                )
-              )
+                  None,
+                ),
+              ),
             ).pure[M]
 
         case (other, _) => MethodNotDefined("union", other.typ).raiseError[M, Expr]
@@ -1135,9 +1133,9 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: CostStateRef](
 
     override def apply(p: Par, args: Seq[Par])(implicit env: Env[Par]): M[Par] =
       for {
-        _ <- MethodArgumentNumberMismatch("union", 1, args.length)
-              .raiseError[M, Unit]
-              .whenA(args.length != 1)
+        _         <- MethodArgumentNumberMismatch("union", 1, args.length)
+                       .raiseError[M, Unit]
+                       .whenA(args.length != 1)
         baseExpr  <- evalSingleExpr(p)
         otherExpr <- evalSingleExpr(args.head)
         result    <- union(baseExpr, otherExpr)
@@ -1157,15 +1155,15 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: CostStateRef](
         case (EMapBody(ParMap(basePs, _, _, _)), EMapBody(ParMap(otherPs, _, _, _))) =>
           charge[M](diffCost(otherPs.size)) >>
             Expr(EMapBody(ParMap(basePs -- otherPs.keys))).pure[M]
-        case (other, _) =>
+        case (other, _)                                                              =>
           MethodNotDefined("diff", other.typ).raiseError[M, Expr]
       }
 
     override def apply(p: Par, args: Seq[Par])(implicit env: Env[Par]): M[Par] =
       for {
-        _ <- MethodArgumentNumberMismatch("diff", 1, args.length)
-              .raiseError[M, Unit]
-              .whenA(args.length != 1)
+        _         <- MethodArgumentNumberMismatch("diff", 1, args.length)
+                       .raiseError[M, Unit]
+                       .whenA(args.length != 1)
         baseExpr  <- evalSingleExpr(p)
         otherExpr <- evalSingleExpr(args.head)
         result    <- diff(baseExpr, otherExpr)
@@ -1183,18 +1181,18 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: CostStateRef](
                 basePs + par,
                 base.connectiveUsed || par.connectiveUsed,
                 base.locallyFree.map(b => b | par.locallyFree),
-                None
-              )
-            )
+                None,
+              ),
+            ),
           ).pure[M]
-        case other => MethodNotDefined("add", other.typ).raiseError[M, Expr]
+        case other                                    => MethodNotDefined("add", other.typ).raiseError[M, Expr]
       }
 
     override def apply(p: Par, args: Seq[Par])(implicit env: Env[Par]): M[Par] =
       for {
-        _ <- MethodArgumentNumberMismatch("add", 1, args.length)
-              .raiseError[M, Unit]
-              .whenA(args.length != 1)
+        _        <- MethodArgumentNumberMismatch("add", 1, args.length)
+                      .raiseError[M, Unit]
+                      .whenA(args.length != 1)
         baseExpr <- evalSingleExpr(p)
         element  <- evalExpr(args.head)
         _        <- charge[M](ADD_COST)
@@ -1213,9 +1211,9 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: CostStateRef](
                 basePs - par,
                 base.connectiveUsed || par.connectiveUsed,
                 base.locallyFree.map(b => b | par.locallyFree),
-                None
-              )
-            )
+                None,
+              ),
+            ),
           ).pure[M]
         case EMapBody(base @ ParMap(basePs, _, _, _)) =>
           Expr(
@@ -1224,22 +1222,25 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: CostStateRef](
                 basePs - par,
                 base.connectiveUsed || par.connectiveUsed,
                 base.locallyFree.map(b => b | par.locallyFree),
-                None
-              )
-            )
+                None,
+              ),
+            ),
           ).pure[M]
-        case other =>
+        case other                                    =>
           MethodNotDefined("delete", other.typ).raiseError[M, Expr]
       }
 
     override def apply(p: Par, args: Seq[Par])(implicit env: Env[Par]): M[Par] =
       for {
-        _ <- MethodArgumentNumberMismatch("delete", 1, args.length)
-              .raiseError[M, Unit]
-              .whenA(args.length != 1)
+        _        <- MethodArgumentNumberMismatch("delete", 1, args.length)
+                      .raiseError[M, Unit]
+                      .whenA(args.length != 1)
         baseExpr <- evalSingleExpr(p)
         element  <- evalExpr(args.head)
-        _        <- charge[M](REMOVE_COST) //TODO(mateusz.gorski): think whether deletion of an element from the collection should dependent on the collection type/size
+        _        <-
+          charge[M](
+            REMOVE_COST,
+          ) // TODO(mateusz.gorski): think whether deletion of an element from the collection should dependent on the collection type/size
         result   <- delete(baseExpr, element)
       } yield result
   }
@@ -1252,14 +1253,14 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: CostStateRef](
           (GBool(basePs.contains(par)): Expr).pure[M]
         case EMapBody(ParMap(basePs, _, _, _)) =>
           (GBool(basePs.contains(par)): Expr).pure[M]
-        case other => MethodNotDefined("contains", other.typ).raiseError[M, Expr]
+        case other                             => MethodNotDefined("contains", other.typ).raiseError[M, Expr]
       }
 
     override def apply(p: Par, args: Seq[Par])(implicit env: Env[Par]): M[Par] =
       for {
-        _ <- MethodArgumentNumberMismatch("contains", 1, args.length)
-              .raiseError[M, Unit]
-              .whenA(args.length != 1)
+        _        <- MethodArgumentNumberMismatch("contains", 1, args.length)
+                      .raiseError[M, Unit]
+                      .whenA(args.length != 1)
         baseExpr <- evalSingleExpr(p)
         element  <- evalExpr(args.head)
         _        <- charge[M](LOOKUP_COST)
@@ -1273,14 +1274,14 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: CostStateRef](
       baseExpr.exprInstance match {
         case EMapBody(ParMap(basePs, _, _, _)) =>
           basePs.getOrElse(key, VectorPar()).pure[M]
-        case other => MethodNotDefined("get", other.typ).raiseError[M, Par]
+        case other                             => MethodNotDefined("get", other.typ).raiseError[M, Par]
       }
 
     override def apply(p: Par, args: Seq[Par])(implicit env: Env[Par]): M[Par] =
       for {
-        _ <- MethodArgumentNumberMismatch("get", 1, args.length)
-              .raiseError[M, Unit]
-              .whenA(args.length != 1)
+        _        <- MethodArgumentNumberMismatch("get", 1, args.length)
+                      .raiseError[M, Unit]
+                      .whenA(args.length != 1)
         baseExpr <- evalSingleExpr(p)
         key      <- evalExpr(args.head)
         _        <- charge[M](LOOKUP_COST)
@@ -1294,14 +1295,14 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: CostStateRef](
       baseExpr.exprInstance match {
         case EMapBody(ParMap(basePs, _, _, _)) =>
           basePs.getOrElse(key, default).pure[M]
-        case other => MethodNotDefined("getOrElse", other.typ).raiseError[M, Par]
+        case other                             => MethodNotDefined("getOrElse", other.typ).raiseError[M, Par]
       }
 
     override def apply(p: Par, args: Seq[Par])(implicit env: Env[Par]): M[Par] =
       for {
-        _ <- MethodArgumentNumberMismatch("getOrElse", 2, args.length)
-              .raiseError[M, Unit]
-              .whenA(args.length != 2)
+        _        <- MethodArgumentNumberMismatch("getOrElse", 2, args.length)
+                      .raiseError[M, Unit]
+                      .whenA(args.length != 2)
         baseExpr <- evalSingleExpr(p)
         key      <- evalExpr(args.head)
         default  <- evalExpr(args(1))
@@ -1316,14 +1317,14 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: CostStateRef](
       baseExpr.exprInstance match {
         case EMapBody(ParMap(basePs, _, _, _)) =>
           (ParMap(basePs + (key -> value)): Par).pure[M]
-        case other => MethodNotDefined("set", other.typ).raiseError[M, Par]
+        case other                             => MethodNotDefined("set", other.typ).raiseError[M, Par]
       }
 
     override def apply(p: Par, args: Seq[Par])(implicit env: Env[Par]): M[Par] =
       for {
-        _ <- MethodArgumentNumberMismatch("set", 2, args.length)
-              .raiseError[M, Unit]
-              .whenA(args.length != 2)
+        _        <- MethodArgumentNumberMismatch("set", 2, args.length)
+                      .raiseError[M, Unit]
+                      .whenA(args.length != 2)
         baseExpr <- evalSingleExpr(p)
         key      <- evalExpr(args.head)
         value    <- evalExpr(args(1))
@@ -1338,15 +1339,15 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: CostStateRef](
       baseExpr.exprInstance match {
         case EMapBody(ParMap(basePs, _, _, _)) =>
           (ParSet(basePs.keys.toSeq): Par).pure[M]
-        case other =>
+        case other                             =>
           MethodNotDefined("keys", other.typ).raiseError[M, Par]
       }
 
     override def apply(p: Par, args: Seq[Par])(implicit env: Env[Par]): M[Par] =
       for {
-        _ <- MethodArgumentNumberMismatch("keys", 0, args.length)
-              .raiseError[M, Unit]
-              .whenA(args.nonEmpty)
+        _        <- MethodArgumentNumberMismatch("keys", 0, args.length)
+                      .raiseError[M, Unit]
+                      .whenA(args.nonEmpty)
         baseExpr <- evalSingleExpr(p)
         _        <- charge[M](KEYS_METHOD_COST)
         result   <- keys(baseExpr)
@@ -1360,18 +1361,18 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: CostStateRef](
         case EMapBody(ParMap(basePs, _, _, _)) =>
           val size = basePs.size
           (size, GInt(size.toLong): Par).pure[M]
-        case ESetBody(ParSet(ps, _, _, _)) =>
+        case ESetBody(ParSet(ps, _, _, _))     =>
           val size = ps.size
           (size, GInt(size.toLong): Par).pure[M]
-        case other =>
+        case other                             =>
           MethodNotDefined("size", other.typ).raiseError[M, (Int, Par)]
       }
 
     override def apply(p: Par, args: Seq[Par])(implicit env: Env[Par]): M[Par] =
       for {
-        _ <- MethodArgumentNumberMismatch("size", 0, args.length)
-              .raiseError[M, Unit]
-              .whenA(args.nonEmpty)
+        _        <- MethodArgumentNumberMismatch("size", 0, args.length)
+                      .raiseError[M, Unit]
+                      .whenA(args.nonEmpty)
         baseExpr <- evalSingleExpr(p)
         result   <- size(baseExpr)
         _        <- charge[M](sizeMethodCost(result._1))
@@ -1382,21 +1383,21 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: CostStateRef](
 
     def length(baseExpr: Expr): M[Expr] =
       baseExpr.exprInstance match {
-        case GString(string) =>
+        case GString(string)               =>
           (GInt(string.length.toLong): Expr).pure[M]
-        case GByteArray(bytes) =>
+        case GByteArray(bytes)             =>
           (GInt(bytes.size.toLong): Expr).pure[M]
         case EListBody(EList(ps, _, _, _)) =>
           (GInt(ps.length.toLong): Expr).pure[M]
-        case other =>
+        case other                         =>
           MethodNotDefined("length", other.typ).raiseError[M, Expr]
       }
 
     override def apply(p: Par, args: Seq[Par])(implicit env: Env[Par]): M[Par] =
       for {
-        _ <- MethodArgumentNumberMismatch("length", 0, args.length)
-              .raiseError[M, Unit]
-              .whenA(args.nonEmpty)
+        _        <- MethodArgumentNumberMismatch("length", 0, args.length)
+                      .raiseError[M, Unit]
+                      .whenA(args.nonEmpty)
         baseExpr <- evalSingleExpr(p)
         _        <- charge[M](LENGTH_METHOD_COST)
         result   <- length(baseExpr)
@@ -1407,21 +1408,21 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: CostStateRef](
 
     def slice(baseExpr: Expr, from: Int, until: Int): M[Par] =
       baseExpr.exprInstance match {
-        case GString(string) =>
+        case GString(string)                                              =>
           Sync[M].delay(GString(string.slice(from, until)))
         case EListBody(EList(ps, locallyFree, connectiveUsed, remainder)) =>
           Sync[M].delay(EList(ps.slice(from, until), locallyFree, connectiveUsed, remainder))
-        case GByteArray(bytes) =>
+        case GByteArray(bytes)                                            =>
           Sync[M].delay(GByteArray(bytes.substring(from, until)))
-        case other =>
+        case other                                                        =>
           MethodNotDefined("slice", other.typ).raiseError[M, Par]
       }
 
     override def apply(p: Par, args: Seq[Par])(implicit env: Env[Par]): M[Par] =
       for {
-        _ <- MethodArgumentNumberMismatch("slice", 2, args.length)
-              .raiseError[M, Unit]
-              .whenA(args.length != 2)
+        _          <- MethodArgumentNumberMismatch("slice", 2, args.length)
+                        .raiseError[M, Unit]
+                        .whenA(args.length != 2)
         baseExpr   <- evalSingleExpr(p)
         fromArgRaw <- evalToLong(args.head)
         fromArg    <- restrictToInt(fromArgRaw)
@@ -1437,15 +1438,15 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: CostStateRef](
       baseExpr.exprInstance match {
         case EListBody(EList(ps, locallyFree, connectiveUsed, remainder)) =>
           Sync[M].delay(EList(ps.take(n), locallyFree, connectiveUsed, remainder))
-        case other =>
+        case other                                                        =>
           MethodNotDefined("take", other.typ).raiseError[M, Par]
       }
 
     override def apply(p: Par, args: Seq[Par])(implicit env: Env[Par]): M[Par] =
       for {
-        _ <- MethodArgumentNumberMismatch("take", 1, args.length)
-              .raiseError[M, Unit]
-              .whenA(args.length != 1)
+        _        <- MethodArgumentNumberMismatch("take", 1, args.length)
+                      .raiseError[M, Unit]
+                      .whenA(args.length != 1)
         baseExpr <- evalSingleExpr(p)
         nArgRaw  <- evalToLong(args.head)
         nArg     <- restrictToInt(nArgRaw)
@@ -1458,7 +1459,7 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: CostStateRef](
 
     def toList(baseExpr: Expr): M[Par] =
       baseExpr.exprInstance match {
-        case e: EListBody =>
+        case e: EListBody                  =>
           (e: Par).pure[M]
         case ESetBody(ParSet(ps, _, _, _)) =>
           charge[M](toListCost(ps.size)) >>
@@ -1466,23 +1467,22 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: CostStateRef](
         case EMapBody(ParMap(ps, _, _, _)) =>
           charge[M](toListCost(ps.size)) >>
             (EList(
-              ps.toSeq.map {
-                case (k, v) =>
-                  Par().withExprs(Seq(Expr(ETupleBody(ETuple(Seq(k, v))))))
-              }
+              ps.toSeq.map { case (k, v) =>
+                Par().withExprs(Seq(Expr(ETupleBody(ETuple(Seq(k, v))))))
+              },
             ): Par).pure[M]
-        case ETupleBody(ETuple(ps, _, _)) =>
+        case ETupleBody(ETuple(ps, _, _))  =>
           charge[M](toListCost(ps.size)) >>
             (EList(ps.toList): Par).pure[M]
-        case other =>
+        case other                         =>
           MethodNotDefined("toList", other.typ).raiseError[M, Par]
       }
 
     override def apply(p: Par, args: Seq[Par])(implicit env: Env[Par]): M[Par] =
       for {
-        _ <- MethodArgumentNumberMismatch("toList", 0, args.length)
-              .raiseError[M, Unit]
-              .whenA(args.nonEmpty)
+        _        <- MethodArgumentNumberMismatch("toList", 0, args.length)
+                      .raiseError[M, Unit]
+                      .whenA(args.nonEmpty)
         baseExpr <- evalSingleExpr(p)
         result   <- toList(baseExpr)
       } yield result
@@ -1491,7 +1491,7 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: CostStateRef](
   private[this] val toSet: Method = new Method() {
     def toSet(baseExpr: Expr): M[Par] =
       baseExpr.exprInstance match {
-        case e: ESetBody =>
+        case e: ESetBody                                                      =>
           (e: Par).pure[M]
         case EMapBody(ParMap(basePs, connectiveUsed, locallyFree, remainder)) =>
           (ESetBody(
@@ -1499,8 +1499,8 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: CostStateRef](
               basePs.toSeq.map(t => ETupleBody(ETuple(Seq(t._1, t._2))): Par),
               connectiveUsed,
               locallyFree,
-              remainder
-            )
+              remainder,
+            ),
           ): Par).pure[M]
         case EListBody(EList(basePs, locallyFree, connectiveUsed, remainder)) =>
           (ESetBody(
@@ -1508,18 +1508,18 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: CostStateRef](
               basePs,
               connectiveUsed,
               locallyFree.get.pure[Eval],
-              remainder
-            )
+              remainder,
+            ),
           ): Par).pure[M]
-        case other =>
+        case other                                                            =>
           MethodNotDefined("toSet", other.typ).raiseError[M, Par]
       }
 
     override def apply(p: Par, args: Seq[Par])(implicit env: Env[Par]): M[Par] =
       for {
-        _ <- MethodArgumentNumberMismatch("toSet", 0, args.length)
-              .raiseError[M, Unit]
-              .whenA(args.nonEmpty)
+        _        <- MethodArgumentNumberMismatch("toSet", 0, args.length)
+                      .raiseError[M, Unit]
+                      .whenA(args.nonEmpty)
         baseExpr <- evalSingleExpr(p)
         result   <- toSet(baseExpr)
       } yield result
@@ -1527,10 +1527,10 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: CostStateRef](
 
   private[this] val toMap: Method = new Method() {
     def makeMap(
-        ps: Seq[Par],
-        connectiveUsed: Boolean,
-        locallyFree: Eval[BitSet],
-        remainder: Option[Var]
+      ps: Seq[Par],
+      connectiveUsed: Boolean,
+      locallyFree: Eval[BitSet],
+      remainder: Option[Var],
     ) = {
       val keyPairs = ps.map(RhoType.RhoTuple2.unapply)
       if (keyPairs.exists(_.isEmpty))
@@ -1541,27 +1541,27 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: CostStateRef](
             keyPairs.flatMap(_.toList),
             connectiveUsed,
             locallyFree,
-            remainder
-          )
+            remainder,
+          ),
         ): Par).pure[M]
     }
     def toMap(baseExpr: Expr): M[Par] =
       baseExpr.exprInstance match {
-        case e: EMapBody =>
+        case e: EMapBody                                                      =>
           (e: Par).pure[M]
         case ESetBody(ParSet(basePs, connectiveUsed, locallyFree, remainder)) =>
           makeMap(basePs.toSeq, connectiveUsed, locallyFree, remainder)
         case EListBody(EList(basePs, locallyFree, connectiveUsed, remainder)) =>
           makeMap(basePs, connectiveUsed, locallyFree.get.pure[Eval], remainder)
-        case other =>
+        case other                                                            =>
           MethodNotDefined("toMap", other.typ).raiseError[M, Par]
       }
 
     override def apply(p: Par, args: Seq[Par])(implicit env: Env[Par]): M[Par] =
       for {
-        _ <- MethodArgumentNumberMismatch("toMap", 0, args.length)
-              .raiseError[M, Unit]
-              .whenA(args.nonEmpty)
+        _        <- MethodArgumentNumberMismatch("toMap", 0, args.length)
+                      .raiseError[M, Unit]
+                      .whenA(args.nonEmpty)
         baseExpr <- evalSingleExpr(p)
         result   <- toMap(baseExpr)
       } yield result
@@ -1591,11 +1591,13 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: CostStateRef](
       "take"        -> take,
       "toList"      -> toList,
       "toSet"       -> toSet,
-      "toMap"       -> toMap
+      "toMap"       -> toMap,
     )
 
   private def evalSingleExpr(p: Par)(implicit env: Env[Par]): M[Expr] =
-    if (p.sends.nonEmpty || p.receives.nonEmpty || p.news.nonEmpty || p.matches.nonEmpty || p.unforgeables.nonEmpty || p.bundles.nonEmpty)
+    if (
+      p.sends.nonEmpty || p.receives.nonEmpty || p.news.nonEmpty || p.matches.nonEmpty || p.unforgeables.nonEmpty || p.bundles.nonEmpty
+    )
       ReduceError("Error: [evalSingleExpr] parallel or non expression found where expression expected.")
         .raiseError[M, Expr]
     else
@@ -1605,66 +1607,70 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: CostStateRef](
       }
 
   private def evalToLong(
-      p: Par
+    p: Par,
   )(implicit env: Env[Par]): M[Long] =
-    if (p.sends.nonEmpty || p.receives.nonEmpty || p.news.nonEmpty || p.matches.nonEmpty || p.unforgeables.nonEmpty || p.bundles.nonEmpty)
+    if (
+      p.sends.nonEmpty || p.receives.nonEmpty || p.news.nonEmpty || p.matches.nonEmpty || p.unforgeables.nonEmpty || p.bundles.nonEmpty
+    )
       ReduceError("Error: [evalToLong] parallel or non expression found where expression expected.")
         .raiseError[M, Long]
     else
       p.exprs match {
-        case Expr(GInt(v)) +: Nil =>
+        case Expr(GInt(v)) +: Nil           =>
           (v: Long).pure[M]
         case Expr(EVarBody(EVar(v))) +: Nil =>
           for {
             p      <- eval(v)
             intVal <- evalToLong(p)
           } yield intVal
-        case (e: Expr) +: Nil =>
+        case (e: Expr) +: Nil               =>
           for {
             evaled <- evalExprToExpr(e)
             result <- evaled.exprInstance match {
-                       case GInt(v) =>
-                         (v: Long).pure[M]
-                       case _ =>
-                         ReduceError("Error: expression didn't evaluate to integer.")
-                           .raiseError[M, Long]
-                     }
+                        case GInt(v) =>
+                          (v: Long).pure[M]
+                        case _       =>
+                          ReduceError("Error: expression didn't evaluate to integer.")
+                            .raiseError[M, Long]
+                      }
           } yield result
-        case _ =>
+        case _                              =>
           ReduceError("Error: Integer expected, or unimplemented expression.").raiseError[M, Long]
       }
 
   private def evalToBool(
-      p: Par
+    p: Par,
   )(implicit env: Env[Par]): M[Boolean] =
-    if (p.sends.nonEmpty || p.receives.nonEmpty || p.news.nonEmpty || p.matches.nonEmpty || p.unforgeables.nonEmpty || p.bundles.nonEmpty)
+    if (
+      p.sends.nonEmpty || p.receives.nonEmpty || p.news.nonEmpty || p.matches.nonEmpty || p.unforgeables.nonEmpty || p.bundles.nonEmpty
+    )
       ReduceError("Error: [evalToBool] parallel or non expression found where expression expected.")
         .raiseError[M, Boolean]
     else
       p.exprs match {
-        case Expr(GBool(b)) +: Nil =>
+        case Expr(GBool(b)) +: Nil          =>
           (b: Boolean).pure[M]
         case Expr(EVarBody(EVar(v))) +: Nil =>
           for {
             p       <- eval(v)
             boolVal <- evalToBool(p)
           } yield boolVal
-        case (e: Expr) +: Nil =>
+        case (e: Expr) +: Nil               =>
           for {
             evaled <- evalExprToExpr(e)
             result <- evaled.exprInstance match {
-                       case GBool(b) => (b: Boolean).pure[M]
-                       case _ =>
-                         ReduceError("Error: expression didn't evaluate to boolean.")
-                           .raiseError[M, Boolean]
-                     }
+                        case GBool(b) => (b: Boolean).pure[M]
+                        case _        =>
+                          ReduceError("Error: expression didn't evaluate to boolean.")
+                            .raiseError[M, Boolean]
+                      }
           } yield result
-        case _ => ReduceError("Error: Multiple expressions given.").raiseError[M, Boolean]
+        case _                              => ReduceError("Error: Multiple expressions given.").raiseError[M, Boolean]
       }
 
   private def restrictToInt(long: Long): M[Int] =
-    Sync[M].catchNonFatal(Math.toIntExact(long)).adaptError {
-      case _: ArithmeticException => ReduceError(s"Integer overflow for value $long")
+    Sync[M].catchNonFatal(Math.toIntExact(long)).adaptError { case _: ArithmeticException =>
+      ReduceError(s"Integer overflow for value $long")
     }
 
   private def updateLocallyFree(par: Par): Par =
@@ -1674,7 +1680,7 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: CostStateRef](
         par.news.foldLeft(BitSet())((acc, newProc) => acc | newProc.locallyFree) |
         par.exprs.foldLeft(BitSet())((acc, expr) => acc | ExprLocallyFree.locallyFree(expr, 0)) |
         par.matches.foldLeft(BitSet())((acc, matchProc) => acc | matchProc.locallyFree) |
-        par.bundles.foldLeft(BitSet())((acc, bundleProc) => acc | bundleProc.locallyFree)
+        par.bundles.foldLeft(BitSet())((acc, bundleProc) => acc | bundleProc.locallyFree),
     )
 
   private def updateLocallyFree(elist: EList): EList =
@@ -1693,6 +1699,6 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: CostStateRef](
       // that locallyFree is for use in the matcher, and the matcher uses
       // substitution, it will resolve in that case. AlwaysEqual makes sure
       // that this isn't an issue in the rest of cases.
-      result = evaledExprs.foldLeft(par.copy(exprs = Vector()))(_ ++ _)
+      result       = evaledExprs.foldLeft(par.copy(exprs = Vector()))(_ ++ _)
     } yield result
 }

--- a/legacy/src/main/scala/coop/rchain/rholang/interpreter/dispatch.scala
+++ b/legacy/src/main/scala/coop/rchain/rholang/interpreter/dispatch.scala
@@ -8,51 +8,63 @@ import coop.rchain.models._
 import coop.rchain.rholang.interpreter.accounting.CostAccounting.CostStateRef
 import coop.rchain.rholang.interpreter.RhoRuntime.RhoTuplespace
 
-trait Dispatch[M[_], A, K] {
-  def dispatch(continuation: K, dataList: Seq[A]): M[Unit]
+trait Dispatch[M[_], B, K] {
+  def dispatch(continuation: K, dataList: Seq[B]): M[Unit]
 }
 
 object Dispatch {
-  def buildEnv(dataList: Seq[ListParWithRandom]): Env[Par] =
-    Env.makeEnv(dataList.flatMap(_.pars): _*)
+  def buildEnv(dataList: Seq[MatchedParsWithRandom]): Env[Par] = {
+    val envMap = dataList.flatMap(_.pars).toMap             // Merge all maps into one
+    // Sanity check to ensure that there are no duplicate keys in the environment
+    // NOTE: It should never happen in the code, so we can use a simple assert.
+    assert(
+      dataList.map(_.pars.size).sum == envMap.size,
+      "Duplicate indices in env during dispatching" + envMap.toString(),
+    )
+    val maxIdx = if (envMap.isEmpty) 0 else envMap.keys.max // Find max De Bruijn index
+    new Env[Par](envMap, level = maxIdx + 1, shift = 0)
+  }
 }
 
 class RholangAndScalaDispatcher[M[_]] private (
-    _dispatchTable: => Map[Long, Seq[ListParWithRandom] => M[Unit]]
+  _dispatchTable: => Map[Long, Seq[ListParWithRandom] => M[Unit]],
 )(implicit s: Sync[M], reducer: Reduce[M])
-    extends Dispatch[M, ListParWithRandom, TaggedContinuation] {
+    extends Dispatch[M, MatchedParsWithRandom, TaggedContinuation] {
+
+  private def toListParWithRandom(ps: MatchedParsWithRandom): ListParWithRandom =
+    ListParWithRandom(ps.pars.toList.sortBy(_._1).map(_._2), ps.randomState)
 
   def dispatch(
-      continuation: TaggedContinuation,
-      dataList: Seq[ListParWithRandom]
+    continuation: TaggedContinuation,
+    dataList: Seq[MatchedParsWithRandom],
   ): M[Unit] =
     continuation.taggedCont match {
       case ParBody(parWithRand) =>
         val env     = Dispatch.buildEnv(dataList)
         val randoms = parWithRand.randomState +: dataList.toVector.map(_.randomState)
         reducer.eval(parWithRand.body)(env, Blake2b512Random.merge(randoms))
-      case ScalaBodyRef(ref) =>
+      case ScalaBodyRef(ref)    =>
         _dispatchTable.get(ref) match {
-          case Some(f) => f(dataList)
+          case Some(f) => f(dataList.map(toListParWithRandom))
           case None    => s.raiseError(new Exception(s"dispatch: no function for $ref"))
         }
-      case Empty =>
+      case Empty                =>
         s.unit
     }
 }
 
 object RholangAndScalaDispatcher {
-  type RhoDispatch[F[_]] = Dispatch[F, ListParWithRandom, TaggedContinuation]
+  type RhoDispatch[F[_]] = Dispatch[F, MatchedParsWithRandom, TaggedContinuation]
 
   def apply[M[_]: Sync: Parallel: CostStateRef](
-      tuplespace: RhoTuplespace[M],
-      dispatchTable: => Map[Long, Seq[ListParWithRandom] => M[Unit]],
-      urnMap: Map[String, Par],
-      mergeChs: Ref[M, Set[Par]],
-      mergeableTagName: Par
-  ): (Dispatch[M, ListParWithRandom, TaggedContinuation], Reduce[M]) = {
+    tuplespace: RhoTuplespace[M],
+    dispatchTable: => Map[Long, Seq[ListParWithRandom] => M[Unit]],
+    urnMap: Map[String, Par],
+    mergeChs: Ref[M, Set[Par]],
+    mergeableTagName: Par,
+  ): (Dispatch[M, MatchedParsWithRandom, TaggedContinuation], Reduce[M]) = {
 
-    implicit lazy val dispatcher: Dispatch[M, ListParWithRandom, TaggedContinuation] =
+    implicit lazy val dispatcher: Dispatch[M, MatchedParsWithRandom, TaggedContinuation] =
       new RholangAndScalaDispatcher(dispatchTable)
 
     implicit lazy val reducer: Reduce[M] =

--- a/legacy/src/main/scala/coop/rchain/rholang/interpreter/storage/ChargingRSpace.scala
+++ b/legacy/src/main/scala/coop/rchain/rholang/interpreter/storage/ChargingRSpace.scala
@@ -1,94 +1,94 @@
 package coop.rchain.rholang.interpreter.storage
 
 import cats.effect.Sync
-import cats.syntax.all._
+import cats.syntax.all.*
 import coop.rchain.crypto.hash.Blake2b512Random
 import coop.rchain.metrics.Span
 import coop.rchain.models.TaggedContinuation.TaggedCont.{Empty, ParBody, ScalaBodyRef}
-import coop.rchain.models._
+import coop.rchain.models.*
+import coop.rchain.rholang.interpreter.MatchedParsWithRandom
 import coop.rchain.rholang.interpreter.accounting.CostAccounting.CostStateRef
 import coop.rchain.rholang.interpreter.RhoRuntime.RhoTuplespace
-import coop.rchain.rholang.interpreter.accounting._
+import coop.rchain.rholang.interpreter.accounting.*
 import coop.rchain.rholang.interpreter.errors.BugFoundError
-import coop.rchain.rspace.{ContResult, Result, Match => StorageMatch}
+import coop.rchain.rspace.{ContResult, Match as StorageMatch, Result}
 
 import java.nio.ByteBuffer
 import scala.collection.SortedSet
 
 object ChargingRSpace {
 
-  private sealed trait TriggeredBy {
+  sealed private trait TriggeredBy {
     val id: Blake2b512Random
     val persistent: Boolean
     val channelsCount: Int
   }
 
-  private final case class Consume(id: Blake2b512Random, persistent: Boolean, channelsCount: Int)
-      extends TriggeredBy
+  final private case class Consume(id: Blake2b512Random, persistent: Boolean, channelsCount: Int) extends TriggeredBy
 
-  private final case class Produce(id: Blake2b512Random, persistent: Boolean) extends TriggeredBy {
+  final private case class Produce(id: Blake2b512Random, persistent: Boolean) extends TriggeredBy {
     override val channelsCount = 1
   }
 
   private def consumeId[F[_]: Sync](continuation: TaggedContinuation): F[Blake2b512Random] =
-    //TODO: Make ScalaBodyRef-s have their own random state and merge it during its COMMs
+    // TODO: Make ScalaBodyRef-s have their own random state and merge it during its COMMs
     continuation.taggedCont match {
-      case ParBody(value) => value.randomState.pure[F]
+      case ParBody(value)      => value.randomState.pure[F]
       case ScalaBodyRef(value) =>
         Blake2b512Random(ByteBuffer.allocate(8).putLong(value).array()).pure[F]
-      case Empty => BugFoundError("Damn you pROTOBUF").raiseError[F, Blake2b512Random]
+      case Empty               => BugFoundError("Damn you pROTOBUF").raiseError[F, Blake2b512Random]
     }
 
   def chargingRSpace[F[_]: Sync: CostStateRef: Span](
-      space: RhoTuplespace[F]
+    space: RhoTuplespace[F],
   ): RhoTuplespace[F] =
     new RhoTuplespace[F] {
 
-      implicit override val m: StorageMatch[F, BindPattern, ListParWithRandom] = space.m
+      implicit override val m: StorageMatch[F, BindPattern, ListParWithRandom, MatchedParsWithRandom] = space.m
 
       override def consume(
-          channels: Seq[Par],
-          patterns: Seq[BindPattern],
-          continuation: TaggedContinuation,
-          persist: Boolean,
-          peeks: SortedSet[Int] = SortedSet.empty[Int]
+        channels: Seq[Par],
+        patterns: Seq[BindPattern],
+        continuation: TaggedContinuation,
+        persist: Boolean,
+        peeks: SortedSet[Int] = SortedSet.empty[Int],
       ): F[
         Option[
-          (ContResult[Par, BindPattern, TaggedContinuation], Seq[Result[Par, ListParWithRandom]])
-        ]
+          (ContResult[Par, BindPattern, TaggedContinuation], Seq[Result[Par, ListParWithRandom, MatchedParsWithRandom]]),
+        ],
       ] =
         for {
-          _ <- charge[F](
-                storageCostConsume(channels, patterns, continuation).copy(
-                  operation = "consume storage"
-                )
-              )
+          _       <- charge[F](
+                       storageCostConsume(channels, patterns, continuation).copy(
+                         operation = "consume storage",
+                       ),
+                     )
           consRes <- space.consume(
-                      channels,
-                      patterns,
-                      continuation,
-                      persist,
-                      peeks
-                    )
-          id <- consumeId(continuation)
-          _  <- handleResult(consRes, Consume(id, persist, channels.size))
+                       channels,
+                       patterns,
+                       continuation,
+                       persist,
+                       peeks,
+                     )
+          id      <- consumeId(continuation)
+          _       <- handleResult(consRes, Consume(id, persist, channels.size))
         } yield consRes
 
       override def install(
-          channels: Seq[Par],
-          patterns: Seq[BindPattern],
-          continuation: TaggedContinuation
+        channels: Seq[Par],
+        patterns: Seq[BindPattern],
+        continuation: TaggedContinuation,
       ): F[Option[(TaggedContinuation, Seq[ListParWithRandom])]] =
         space.install(channels, patterns, continuation)
 
       override def produce(
-          channel: Par,
-          data: ListParWithRandom,
-          persist: Boolean
+        channel: Par,
+        data: ListParWithRandom,
+        persist: Boolean,
       ): F[
         Option[
-          (ContResult[Par, BindPattern, TaggedContinuation], Seq[Result[Par, ListParWithRandom]])
-        ]
+          (ContResult[Par, BindPattern, TaggedContinuation], Seq[Result[Par, ListParWithRandom, MatchedParsWithRandom]]),
+        ],
       ] =
         for {
           _       <- charge[F](storageCostProduce(channel, data).copy(operation = "produces storage"))
@@ -97,10 +97,10 @@ object ChargingRSpace {
         } yield prodRes
 
       private def handleResult(
-          result: Option[
-            (ContResult[Par, BindPattern, TaggedContinuation], Seq[Result[Par, ListParWithRandom]])
-          ],
-          triggeredBy: TriggeredBy
+        result: Option[
+          (ContResult[Par, BindPattern, TaggedContinuation], Seq[Result[Par, ListParWithRandom, MatchedParsWithRandom]]),
+        ],
+        triggeredBy: TriggeredBy,
       ): F[Unit] =
         result match {
 
@@ -112,34 +112,33 @@ object ChargingRSpace {
 
               // We refund for non-persistent continuations, and for the persistent continuation triggering the comm.
               // That persistent continuation is going to be charged for (without refund) once it has no matches in TS.
-              refundForConsume = if (!cont.persistent || consumeId == triggeredBy.id) {
-                storageCostConsume(cont.channels, cont.patterns, cont.continuation)
-              } else {
-                Cost(0)
-              }
+              refundForConsume  = if (!cont.persistent || consumeId == triggeredBy.id) {
+                                    storageCostConsume(cont.channels, cont.patterns, cont.continuation)
+                                  } else {
+                                    Cost(0)
+                                  }
               refundForProduces = refundForRemovingProduces(dataList, cont, triggeredBy)
 
-              _             <- charge[F](Cost(-refundForConsume.value, "consume storage refund"))
-              _             <- charge[F](Cost(-refundForProduces.value, "produces storage refund"))
+              _            <- charge[F](Cost(-refundForConsume.value, "consume storage refund"))
+              _            <- charge[F](Cost(-refundForProduces.value, "produces storage refund"))
               lastIteration = !triggeredBy.persistent
-              _             <- charge[F](eventStorageCost(triggeredBy.channelsCount)).whenA(lastIteration)
-              _             <- charge[F](commEventStorageCost(cont.channels.size))
+              _            <- charge[F](eventStorageCost(triggeredBy.channelsCount)).whenA(lastIteration)
+              _            <- charge[F](commEventStorageCost(cont.channels.size))
             } yield ()
         }
 
       private def refundForRemovingProduces(
-          dataList: Seq[Result[Par, ListParWithRandom]],
-          cont: ContResult[Par, BindPattern, TaggedContinuation],
-          triggeredBy: TriggeredBy
+        dataList: Seq[Result[Par, ListParWithRandom, MatchedParsWithRandom]],
+        cont: ContResult[Par, BindPattern, TaggedContinuation],
+        triggeredBy: TriggeredBy,
       ): Cost = {
         val removedData = dataList
           .zip(cont.channels)
           // A persistent produce is charged for upfront before reaching the TS, and needs to be refunded
           // after each iteration it matches an existing consume. We treat it as 'removed' on each such iteration.
           // It is going to be 'not removed' and charged for on the last iteration, where it doesn't match anything.
-          .filter {
-            case (data, _) =>
-              !data.persistent || data.removedDatum.randomState == triggeredBy.id
+          .filter { case (data, _) =>
+            !data.persistent || data.removedDatum.randomState == triggeredBy.id
           }
         removedData
           .map { case (data, channel) => storageCostProduce(channel, data.removedDatum) }

--- a/legacy/src/main/scala/coop/rchain/rholang/interpreter/storage/package.scala
+++ b/legacy/src/main/scala/coop/rchain/rholang/interpreter/storage/package.scala
@@ -1,60 +1,47 @@
 package coop.rchain.rholang.interpreter
 
 import cats.effect.Sync
-import cats.mtl.implicits._
-import cats.syntax.all._
+import cats.mtl.implicits.*
+import cats.syntax.all.*
 import coop.rchain.metrics.Span
+import coop.rchain.models.*
 import coop.rchain.models.Var.VarInstance.FreeVar
-import coop.rchain.models._
-import coop.rchain.models.rholang.implicits._
+import coop.rchain.models.rholang.implicits.*
 import coop.rchain.models.serialization.implicits.mkProtobufInstance
-import coop.rchain.rholang.interpreter.matcher._
-import coop.rchain.rspace.{Match => StorageMatch}
+import coop.rchain.rholang.interpreter.matcher.*
+import coop.rchain.rspace.Match as StorageMatch
 import coop.rchain.shared.Serialize
 
-//noinspection ConvertExpressionToSAM
 package object storage {
 
   /* Match instance */
-
-  private def toSeq(fm: FreeMap, max: Int): Seq[Par] =
-    (0 until max).map { (i: Int) =>
-      fm.get(i) match {
-        case Some(par) => par
-        case None      => Par.defaultInstance
-      }
-    }
-
-  def matchListPar[F[_]: Sync: Span]: StorageMatch[F, BindPattern, ListParWithRandom] =
-    new StorageMatch[F, BindPattern, ListParWithRandom] {
+  def matchListPar[F[_]: Sync: Span]: StorageMatch[F, BindPattern, ListParWithRandom, MatchedParsWithRandom] =
+    new StorageMatch[F, BindPattern, ListParWithRandom, MatchedParsWithRandom] {
       def get(
-          pattern: BindPattern,
-          data: ListParWithRandom
-      ): F[Option[ListParWithRandom]] = {
+        pattern: BindPattern,
+        data: ListParWithRandom,
+      ): F[Option[MatchedParsWithRandom]] = {
         type R[A] = MatcherMonadT[F, A]
         implicit val matcherMonadError = implicitly[Sync[R]]
         for {
           matchResult <- runFirst[F, Seq[Par]](
-                          SpatialMatcher
-                            .foldMatch[R, Par, Par](
-                              data.pars,
-                              pattern.patterns,
-                              pattern.remainder
-                            )
-                        )
-        } yield {
-          matchResult.map {
-            case (freeMap, caughtRem) =>
-              val remainderMap = pattern.remainder match {
-                case Some(Var(FreeVar(level))) =>
-                  freeMap + (level -> VectorPar().addExprs(EList(caughtRem.toVector)))
-                case _ => freeMap
-              }
-              ListParWithRandom(
-                toSeq(remainderMap, pattern.freeCount),
-                data.randomState
-              )
+                           SpatialMatcher
+                             .foldMatch[R, Par, Par](
+                               data.pars,
+                               pattern.patterns,
+                               pattern.remainder,
+                             ),
+                         )
+        } yield matchResult.map { case (freeMap, caughtRem) =>
+          val remainderMap = pattern.remainder match {
+            case Some(Var(FreeVar(level))) =>
+              freeMap + (level -> VectorPar().addExprs(EList(caughtRem.toVector)))
+            case _                         => freeMap
           }
+          MatchedParsWithRandom(
+            remainderMap,
+            data.randomState,
+          )
         }
       }
     }

--- a/legacy/src/main/scala/coop/rchain/rspace/IReplaySpace.scala
+++ b/legacy/src/main/scala/coop/rchain/rspace/IReplaySpace.scala
@@ -9,7 +9,7 @@ import coop.rchain.rspace.util.ReplayException
 import coop.rchain.shared.Log
 import sdk.log.LogSourceMacroInstance.logSource
 
-trait IReplaySpace[F[_], C, P, A, K] extends ISpace[F, C, P, A, K] {
+trait IReplaySpace[F[_], C, P, A, K, B] extends ISpace[F, C, P, A, K, B] {
 
   protected def logF: Log[F]
 

--- a/legacy/src/main/scala/coop/rchain/rspace/ISpace.scala
+++ b/legacy/src/main/scala/coop/rchain/rspace/ISpace.scala
@@ -3,9 +3,9 @@ package coop.rchain.rspace
 import coop.rchain.rspace.hashing.Blake2b256Hash
 import coop.rchain.rspace.internal._
 
-final case class Result[C, A](
+final case class Result[C, A, B](
     channel: C,
-    matchedDatum: A,
+    matchedDatum: B,
     removedDatum: A,
     persistent: Boolean
 )
@@ -24,7 +24,7 @@ final case class ContResult[C, P, K](
   * @tparam A a type representing an arbitrary piece of data and match result
   * @tparam K a type representing a continuation
   */
-trait ISpace[F[_], C, P, A, K] extends Tuplespace[F, C, P, A, K] {
+trait ISpace[F[_], C, P, A, K, B] extends Tuplespace[F, C, P, A, K, B] {
 
   /** Creates a checkpoint.
     *

--- a/legacy/src/main/scala/coop/rchain/rspace/Match.scala
+++ b/legacy/src/main/scala/coop/rchain/rspace/Match.scala
@@ -4,9 +4,10 @@ package coop.rchain.rspace
   * Type class for matching patterns with data.
   *
   * @tparam P A type representing patterns
-  * @tparam A A type representing data and match result
+  * @tparam A A type representing input data
+  * @tparam B A type representing matched data
   */
-trait Match[F[_], P, A] {
+trait Match[F[_], P, A, B] {
 
-  def get(p: P, a: A): F[Option[A]]
+  def get(p: P, a: A): F[Option[B]]
 }

--- a/legacy/src/main/scala/coop/rchain/rspace/Tuplespace.scala
+++ b/legacy/src/main/scala/coop/rchain/rspace/Tuplespace.scala
@@ -2,9 +2,9 @@ package coop.rchain.rspace
 
 import scala.collection.SortedSet
 
-trait Tuplespace[F[_], C, P, A, K] {
+trait Tuplespace[F[_], C, P, A, K, B] {
 
-  implicit val m: Match[F, P, A]
+  implicit val m: Match[F, P, A, B]
 
   /** Searches the store for data matching all the given patterns at the given channels.
     *
@@ -35,7 +35,7 @@ trait Tuplespace[F[_], C, P, A, K] {
     continuation: K,
     persist: Boolean,
     peeks: SortedSet[Int] = SortedSet.empty,
-  ): F[Option[(ContResult[C, P, K], Seq[Result[C, A]])]]
+  ): F[Option[(ContResult[C, P, K], Seq[Result[C, A, B]])]]
 
   /** Searches the store for a continuation that has patterns that match the given data at the
     * given channel.
@@ -64,7 +64,7 @@ trait Tuplespace[F[_], C, P, A, K] {
     channel: C,
     data: A,
     persist: Boolean,
-  ): F[Option[(ContResult[C, P, K], Seq[Result[C, A]])]]
+  ): F[Option[(ContResult[C, P, K], Seq[Result[C, A, B]])]]
 
   def install(channels: Seq[C], patterns: Seq[P], continuation: K): F[Option[(K, Seq[A])]]
 }

--- a/legacy/src/main/scala/coop/rchain/rspace/examples/AddressBookExample.scala
+++ b/legacy/src/main/scala/coop/rchain/rspace/examples/AddressBookExample.scala
@@ -142,7 +142,7 @@ object AddressBookExample {
       */
     implicit def matchPatternEntry[F[_]](implicit
       apF: Applicative[F],
-    ): Match[F, Pattern, Entry] =
+    ): Match[F, Pattern, Entry, Entry] =
       (p: Pattern, a: Entry) =>
         p match {
           case NameMatch(last) if a.name.last == last        => apF.pure(Some(a))
@@ -186,7 +186,7 @@ object AddressBookExample {
 
     // Let's define our store
     val store = keyValueStoreManager.rSpaceStores
-    val space = RSpace.create[Id, Channel, Pattern, Entry, Printer](store)
+    val space = RSpace.create[Id, Channel, Pattern, Entry, Printer, Entry](store)
 
     Console.printf("\nExample One: Let's consume and then produce...\n")
 
@@ -221,7 +221,7 @@ object AddressBookExample {
 
     // Let's define our store
     val store = keyValueStoreManager.rSpaceStores
-    val space = RSpace.create[Id, Channel, Pattern, Entry, Printer](store)
+    val space = RSpace.create[Id, Channel, Pattern, Entry, Printer, Entry](store)
 
     Console.printf("\nExample Two: Let's produce and then consume...\n")
 
@@ -298,7 +298,7 @@ object AddressBookExample {
   }
 
   private[this] def withSpace(
-    f: ISpace[Id, Channel, Pattern, Entry, Printer] => Unit,
+    f: ISpace[Id, Channel, Pattern, Entry, Printer, Entry] => Unit,
   ) = {
 
     implicit val log: Log[Id]          = Log.log
@@ -308,7 +308,7 @@ object AddressBookExample {
 
     // Let's define our store
     val store = keyValueStoreManager.rSpaceStores
-    val space = RSpace.create[Id, Channel, Pattern, Entry, Printer](store)
+    val space = RSpace.create[Id, Channel, Pattern, Entry, Printer, Entry](store)
     try
       f(space)
     finally

--- a/legacy/src/main/scala/coop/rchain/rspace/examples/StringExamples.scala
+++ b/legacy/src/main/scala/coop/rchain/rspace/examples/StringExamples.scala
@@ -51,7 +51,7 @@ object StringExamples {
 
   object implicits {
 
-    implicit def stringMatch[F[_]: Sync]: Match[F, Pattern, String] =
+    implicit def stringMatch[F[_]: Sync]: Match[F, Pattern, String, String] =
       (p: Pattern, a: String) => Sync[F].pure(Some(a).filter(p.isMatch))
 
     implicit object stringSerialize extends Serialize[String] {

--- a/legacy/src/main/scala/coop/rchain/rspace/internal.scala
+++ b/legacy/src/main/scala/coop/rchain/rspace/internal.scala
@@ -51,18 +51,18 @@ object internal {
       )
   }
 
-  final case class ConsumeCandidate[C, A](
+  final case class ConsumeCandidate[C, A, B](
     channel: C,
-    datum: Datum[A],
+    datum: Datum[B],
     removedDatum: A,
     datumIndex: Int,
   )
 
-  final case class ProduceCandidate[C, P, A, K](
+  final case class ProduceCandidate[C, P, A, K, B](
     channels: Seq[C],
     continuation: WaitingContinuation[P, K],
     continuationIndex: Int,
-    dataCandidates: Seq[ConsumeCandidate[C, A]],
+    dataCandidates: Seq[ConsumeCandidate[C, A, B]],
   )
 
   final case class Row[P, A, K](data: Seq[Datum[A]], wks: Seq[WaitingContinuation[P, K]])

--- a/legacy/src/main/scala/coop/rchain/rspace/trace/Event.scala
+++ b/legacy/src/main/scala/coop/rchain/rspace/trace/Event.scala
@@ -25,8 +25,8 @@ final case class COMM(
 ) extends Event
 
 object COMM {
-  def apply[F[_]: Sync, C, A](
-    dataCandidates: Seq[ConsumeCandidate[C, A]],
+  def apply[F[_]: Sync, C, A, B](
+    dataCandidates: Seq[ConsumeCandidate[C, A, B]],
     consumeRef: Consume,
     peeks: SortedSet[Int],
     produceCounters: Seq[Produce] => F[Map[Produce, Int]],

--- a/legacy/src/main/scala/coop/rchain/rspace/util/package.scala
+++ b/legacy/src/main/scala/coop/rchain/rspace/util/package.scala
@@ -8,32 +8,32 @@ import scala.util.Try
 
 package object util {
 
-  def unpackSeq[C, P, K, R](
-    v: Seq[Option[(ContResult[C, P, K], Seq[Result[C, R]])]],
-  ): Seq[Option[(K, Seq[R])]] =
+  def unpackSeq[C, P, K, R, B](
+    v: Seq[Option[(ContResult[C, P, K], Seq[Result[C, R, B]])]],
+  ): Seq[Option[(K, Seq[B])]] =
     v.map(unpackOption)
 
-  def unpackOption[C, P, K, R](
-    v: Option[(ContResult[C, P, K], Seq[Result[C, R]])],
-  ): Option[(K, Seq[R])] =
+  def unpackOption[C, P, K, R, B](
+    v: Option[(ContResult[C, P, K], Seq[Result[C, R, B]])],
+  ): Option[(K, Seq[B])] =
     v.map(unpackTuple)
 
-  def unpackTuple[C, P, K, R](
-    v: (ContResult[C, P, K], Seq[Result[C, R]]),
-  ): (K, Seq[R]) =
+  def unpackTuple[C, P, K, R, B](
+    v: (ContResult[C, P, K], Seq[Result[C, R, B]]),
+  ): (K, Seq[B]) =
     v match {
       case (ContResult(continuation, _, _, _, _), data) =>
         (continuation, data.map(_.matchedDatum))
     }
 
-  def unpackOptionWithPeek[C, P, K, R](
-    v: Option[(ContResult[C, P, K], Seq[Result[C, R]])],
-  ): Option[(K, Seq[(C, R, R, Boolean)], Boolean)] =
+  def unpackOptionWithPeek[C, P, K, R, B](
+    v: Option[(ContResult[C, P, K], Seq[Result[C, R, B]])],
+  ): Option[(K, Seq[(C, B, R, Boolean)], Boolean)] =
     v.map(unpackTupleWithPeek)
 
-  def unpackTupleWithPeek[C, P, K, R](
-    v: (ContResult[C, P, K], Seq[Result[C, R]]),
-  ): (K, Seq[(C, R, R, Boolean)], Boolean) =
+  def unpackTupleWithPeek[C, P, K, R, B](
+    v: (ContResult[C, P, K], Seq[Result[C, R, B]]),
+  ): (K, Seq[(C, B, R, Boolean)], Boolean) =
     v match {
       case (ContResult(continuation, _, _, _, peek), data) =>
         (

--- a/legacy/src/main/scala/io/rhonix/rholang/normalizer/ContractNormalizer.scala
+++ b/legacy/src/main/scala/io/rhonix/rholang/normalizer/ContractNormalizer.scala
@@ -12,7 +12,7 @@ import scala.jdk.CollectionConverters.*
 object ContractNormalizer {
   def normalizeContract[
     F[_]: Sync: NormalizerRec: BoundVarScope: FreeVarScope: NestingWriter,
-    T: BoundVarWriter: FreeVarReader,
+    T: BoundVarWriter: BoundVarReader: FreeVarReader,
   ](p: PContr): F[ReceiveN] =
     for {
       source <- NormalizerRec[F].normalize(p.name_)

--- a/legacy/src/main/scala/io/rhonix/rholang/normalizer/InputNormalizer.scala
+++ b/legacy/src/main/scala/io/rhonix/rholang/normalizer/InputNormalizer.scala
@@ -15,7 +15,7 @@ object InputNormalizer {
   @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
   def normalizeInput[
     F[_]: Sync: NormalizerRec: BoundVarScope: FreeVarScope: NestingWriter,
-    T: BoundVarWriter: FreeVarReader,
+    T: BoundVarWriter: BoundVarReader: FreeVarReader,
   ](p: PInput): F[ParN] = {
     if (p.listreceipt_.size() > 1) {
       NormalizerRec[F].normalize(

--- a/legacy/src/main/scala/io/rhonix/rholang/normalizer/LetNormalizer.scala
+++ b/legacy/src/main/scala/io/rhonix/rholang/normalizer/LetNormalizer.scala
@@ -14,7 +14,7 @@ import scala.jdk.CollectionConverters.*
 object LetNormalizer {
   def normalizeLet[
     F[_]: Sync: NormalizerRec: BoundVarScope: FreeVarScope: NestingWriter,
-    T: BoundVarWriter: FreeVarReader,
+    T: BoundVarWriter: BoundVarReader: FreeVarReader,
   ](p: PLet): F[ParN] =
     p.decls_ match {
 

--- a/legacy/src/main/scala/io/rhonix/rholang/normalizer/MatchNormalizer.scala
+++ b/legacy/src/main/scala/io/rhonix/rholang/normalizer/MatchNormalizer.scala
@@ -13,7 +13,7 @@ import scala.jdk.CollectionConverters.*
 object MatchNormalizer {
   def normalizeMatch[
     F[_]: Sync: NormalizerRec: BoundVarScope: FreeVarScope: NestingWriter,
-    T: BoundVarWriter: FreeVarReader,
+    T: BoundVarWriter: BoundVarReader: FreeVarReader,
   ](p: PMatch): F[MatchN] = {
     def normalizeCase(c: Case): F[MatchCaseN] = c match {
       case ci: CaseImpl =>

--- a/legacy/src/main/scala/io/rhonix/rholang/normalizer/MatchesNormalizer.scala
+++ b/legacy/src/main/scala/io/rhonix/rholang/normalizer/MatchesNormalizer.scala
@@ -1,6 +1,6 @@
 package io.rhonix.rholang.normalizer
 
-import cats.Apply
+import cats.effect.Sync
 import cats.syntax.all.*
 import io.rhonix.rholang.ast.rholang.Absyn.{PMatches, Proc}
 import io.rhonix.rholang.normalizer.env.*
@@ -8,7 +8,7 @@ import io.rhonix.rholang.normalizer.syntax.all.*
 import io.rhonix.rholang.types.EMatchesN
 
 object MatchesNormalizer {
-  def normalizeMatches[F[_]: Apply: NormalizerRec: BoundVarScope: FreeVarScope: NestingWriter](
+  def normalizeMatches[F[_]: Sync: NormalizerRec: BoundVarScope: FreeVarScope: NestingWriter, T: BoundVarReader](
     p: PMatches,
   ): F[EMatchesN] = {
     // The expression "target matches pattern" should have the same semantics as "match target { pattern => true ; _ => false}".

--- a/legacy/src/main/scala/io/rhonix/rholang/normalizer/Normalizer.scala
+++ b/legacy/src/main/scala/io/rhonix/rholang/normalizer/Normalizer.scala
@@ -17,7 +17,7 @@ object Normalizer {
    *       This approach ensures compatibility with the legacy reducer and associated tests.
    *       However, it should be rewritten using non-inverted methods following the completion of reducer rewriting.
    */
-  val BOUND_VAR_INDEX_REVERSED = true
+  val BOUND_VAR_INDEX_REVERSED = false
 
   /** Normalizes parser AST types to core Rholang AST types. Entry point of the normalizer.
    *

--- a/legacy/src/main/scala/io/rhonix/rholang/normalizer/Normalizer.scala
+++ b/legacy/src/main/scala/io/rhonix/rholang/normalizer/Normalizer.scala
@@ -8,17 +8,6 @@ import io.rhonix.rholang.types.*
 
 object Normalizer {
 
-  /**
-   * Flag to determine if normalizer will use reverse index when creating [[io.rhonix.rholang.types.BoundVarN]] term.
-   *
-   * NOTE: This flag exists to track where reverse index is used.
-   *
-   * TODO: Utilized get methods with index inversion as it functions equivalently to the legacy implementation.
-   *       This approach ensures compatibility with the legacy reducer and associated tests.
-   *       However, it should be rewritten using non-inverted methods following the completion of reducer rewriting.
-   */
-  val BOUND_VAR_INDEX_REVERSED = false
-
   /** Normalizes parser AST types to core Rholang AST types. Entry point of the normalizer.
    *
    * @param proc input parser AST object.

--- a/legacy/src/main/scala/io/rhonix/rholang/normalizer/NormalizerRecImpl.scala
+++ b/legacy/src/main/scala/io/rhonix/rholang/normalizer/NormalizerRecImpl.scala
@@ -67,8 +67,8 @@ final case class NormalizerRecImpl[F[_]: Sync, T >: VarSort]() extends Normalize
 
   // TODO: Temporary initialization function to use in tests until complete solution is created.
   def init: this.type = {
-    boundMapChain.push(VarMap.default[T])
-    freeMapChain.push(VarMap.default[T])
+    boundMapChain.push(VarMap.default[T]())
+    freeMapChain.push(VarMap.default[T]())
     this
   }
 }
@@ -108,7 +108,7 @@ object NormalizerRecImpl {
       /* Binary expressions (2-arity constructors) */
       /* ========================================= */
       case p: PPar            => ParNormalizer.normalizePar[F](p)
-      case p: PMatches        => MatchesNormalizer.normalizeMatches[F](p).widen
+      case p: PMatches        => MatchesNormalizer.normalizeMatches[F, T](p).widen
       case p: PConjunction    => ConjunctionNormalizer.normalizeConjunction[F](p).widen
       case p: PDisjunction    => DisjunctionNormalizer.normalizeDisjunction[F](p).widen
       case p: PMult           => binaryExp(p.proc_1, p.proc_2, EMultN.apply)

--- a/legacy/src/main/scala/io/rhonix/rholang/normalizer/VarRefNormalizer.scala
+++ b/legacy/src/main/scala/io/rhonix/rholang/normalizer/VarRefNormalizer.scala
@@ -14,7 +14,7 @@ object VarRefNormalizer {
   )(implicit nestingInfo: NestingReader): F[ConnVarRefN] =
     Sync[F].delay(BoundVarReader[T].findBoundVar(p.var_)).flatMap {
       // Found bounded variable
-      case Some(VarContext(index, _, kind, sourcePosition)) =>
+      case Some(VarContext(index, kind, sourcePosition)) =>
         val depth = nestingInfo.patternDepth
         // TODO: Throw an exception if VarRef is outside the pattern?
         kind match {

--- a/legacy/src/main/scala/io/rhonix/rholang/normalizer/env/BoundVarReader.scala
+++ b/legacy/src/main/scala/io/rhonix/rholang/normalizer/env/BoundVarReader.scala
@@ -16,6 +16,12 @@ trait BoundVarReader[T] {
    * @return bound variable or None .
    */
   def findBoundVar(name: String): Option[VarContext[T]]
+
+  /**
+   * Get next de Bruijn index.
+   * @return index that will be used for the creation of the next bound variable within the current scope.
+   */
+  def getNextIndex: Int
 }
 
 object BoundVarReader {

--- a/legacy/src/main/scala/io/rhonix/rholang/normalizer/env/FreeVarScope.scala
+++ b/legacy/src/main/scala/io/rhonix/rholang/normalizer/env/FreeVarScope.scala
@@ -2,8 +2,13 @@ package io.rhonix.rholang.normalizer.env
 
 trait FreeVarScope[F[_]] {
 
-  /** Run function within an empty free variables scope (preserving history). */
-  def withNewFreeVarScope[R](scopeFn: F[R]): F[R]
+  /** Run function within an empty free variables scope (preserving history).
+   * @tparam R The type of the result produced by the function `scopeFn`.
+   * @param scopeFn The function to be executed within the new scope of free variables.
+   * @param startIndex The de Bruijn index to be used for the first free variable created within the new scope. Defaults to 0.
+   * @return The result of executing the function `scopeFn` within the new scope of free variables.
+   */
+  def withNewFreeVarScope[R](scopeFn: F[R], startIndex: Int = 0): F[R]
 }
 
 object FreeVarScope {

--- a/legacy/src/main/scala/io/rhonix/rholang/normalizer/env/VarContext.scala
+++ b/legacy/src/main/scala/io/rhonix/rholang/normalizer/env/VarContext.scala
@@ -6,9 +6,8 @@ import coop.rchain.rholang.interpreter.compiler.SourcePosition
  * Context of a variable (free or bound).
  *
  * @param index index in a free or bound map.
- * @param indexRev reversed index bottom-up from the latest index.
  * @param typ type of the variable.
  * @param sourcePosition source position of the variable.
  * @tparam T type of the variable.
  */
-final case class VarContext[T](index: Int, indexRev: Int, typ: T, sourcePosition: SourcePosition)
+final case class VarContext[T](index: Int, typ: T, sourcePosition: SourcePosition)

--- a/legacy/src/main/scala/io/rhonix/rholang/normalizer/envimpl/BoundVarReaderImpl.scala
+++ b/legacy/src/main/scala/io/rhonix/rholang/normalizer/envimpl/BoundVarReaderImpl.scala
@@ -4,6 +4,7 @@ import io.rhonix.rholang.normalizer.env.*
 import io.rhonix.rholang.normalizer.syntax.all.*
 
 final case class BoundVarReaderImpl[T](chain: HistoryChain[VarMap[T]]) extends BoundVarReader[T] {
-  override def getBoundVar(name: String): Option[VarContext[T]]  = chain.current().get(name)
+  override def getBoundVar(name: String): Option[VarContext[T]]  = chain.current().flatMap(_.get(name))
   override def findBoundVar(name: String): Option[VarContext[T]] = chain.getFirstVarInChain(name)
+  override def getNextIndex: Int                                 = chain.current().map(_.nextIndex).getOrElse(0)
 }

--- a/legacy/src/main/scala/io/rhonix/rholang/normalizer/envimpl/BoundVarScopeImpl.scala
+++ b/legacy/src/main/scala/io/rhonix/rholang/normalizer/envimpl/BoundVarScopeImpl.scala
@@ -5,6 +5,7 @@ import io.rhonix.rholang.normalizer.env.BoundVarScope
 import io.rhonix.rholang.normalizer.syntax.all.*
 
 final case class BoundVarScopeImpl[F[_]: Sync, T](chain: HistoryChain[VarMap[T]]) extends BoundVarScope[F] {
-  override def withNewBoundVarScope[R](scopeFn: F[R]): F[R]  = chain.runWithNewDataInChain(scopeFn, VarMap.default[T])
-  override def withCopyBoundVarScope[R](scopeFn: F[R]): F[R] = chain.runWithNewDataInChain(scopeFn, chain.current())
+  override def withNewBoundVarScope[R](scopeFn: F[R]): F[R]  = chain.runWithNewDataInChain(scopeFn, VarMap.default[T]())
+  override def withCopyBoundVarScope[R](scopeFn: F[R]): F[R] =
+    chain.runWithNewDataInChain(scopeFn, chain.current().getOrElse(VarMap.default()))
 }

--- a/legacy/src/main/scala/io/rhonix/rholang/normalizer/envimpl/FreeVarReaderImpl.scala
+++ b/legacy/src/main/scala/io/rhonix/rholang/normalizer/envimpl/FreeVarReaderImpl.scala
@@ -5,14 +5,13 @@ import io.rhonix.rholang.normalizer.env.*
 
 final case class FreeVarReaderImpl[T](chain: HistoryChain[VarMap[T]]) extends FreeVarReader[T] {
   override def getFreeVars: Seq[(String, FreeContext[T])] =
-    chain.current().getOrElse(VarMap.default()).data.toSeq.map {
-      case (name, VarContext(index, _, typ, sourcePosition)) =>
-        (name, FreeContext(index, typ, sourcePosition))
+    chain.current().getOrElse(VarMap.default()).data.toSeq.map { case (name, VarContext(index, typ, sourcePosition)) =>
+      (name, FreeContext(index, typ, sourcePosition))
     }
 
   override def getFreeVar(name: String): Option[FreeContext[T]] = chain
     .current()
-    .flatMap(_.get(name).map { case VarContext(index, _, typ, sourcePosition) =>
+    .flatMap(_.get(name).map { case VarContext(index, typ, sourcePosition) =>
       FreeContext(index, typ, sourcePosition)
     })
 }

--- a/legacy/src/main/scala/io/rhonix/rholang/normalizer/envimpl/FreeVarReaderImpl.scala
+++ b/legacy/src/main/scala/io/rhonix/rholang/normalizer/envimpl/FreeVarReaderImpl.scala
@@ -5,11 +5,14 @@ import io.rhonix.rholang.normalizer.env.*
 
 final case class FreeVarReaderImpl[T](chain: HistoryChain[VarMap[T]]) extends FreeVarReader[T] {
   override def getFreeVars: Seq[(String, FreeContext[T])] =
-    chain.current().data.toSeq.map { case (name, VarContext(index, _, typ, sourcePosition)) =>
-      (name, FreeContext(index, typ, sourcePosition))
+    chain.current().getOrElse(VarMap.default()).data.toSeq.map {
+      case (name, VarContext(index, _, typ, sourcePosition)) =>
+        (name, FreeContext(index, typ, sourcePosition))
     }
 
-  override def getFreeVar(name: String): Option[FreeContext[T]] = chain.current().get(name).map {
-    case VarContext(index, _, typ, sourcePosition) => FreeContext(index, typ, sourcePosition)
-  }
+  override def getFreeVar(name: String): Option[FreeContext[T]] = chain
+    .current()
+    .flatMap(_.get(name).map { case VarContext(index, _, typ, sourcePosition) =>
+      FreeContext(index, typ, sourcePosition)
+    })
 }

--- a/legacy/src/main/scala/io/rhonix/rholang/normalizer/envimpl/FreeVarScopeImpl.scala
+++ b/legacy/src/main/scala/io/rhonix/rholang/normalizer/envimpl/FreeVarScopeImpl.scala
@@ -5,5 +5,6 @@ import io.rhonix.rholang.normalizer.env.FreeVarScope
 import io.rhonix.rholang.normalizer.syntax.all.*
 
 final case class FreeVarScopeImpl[F[_]: Sync, T](chain: HistoryChain[VarMap[T]]) extends FreeVarScope[F] {
-  override def withNewFreeVarScope[R](scopeFn: F[R]): F[R] = chain.runWithNewDataInChain(scopeFn, VarMap.default[T])
+  override def withNewFreeVarScope[R](scopeFn: F[R], startIndex: Int): F[R] =
+    chain.runWithNewDataInChain(scopeFn, VarMap.default[T](startIndex))
 }

--- a/legacy/src/main/scala/io/rhonix/rholang/normalizer/envimpl/HistoryChain.scala
+++ b/legacy/src/main/scala/io/rhonix/rholang/normalizer/envimpl/HistoryChain.scala
@@ -10,9 +10,9 @@ final class HistoryChain[T](private val chain: collection.mutable.ListBuffer[T])
 
   /**
    * Retrieve the current (last) element of the chain.
-   * @return the last element of the chain
+   * @return An Option containing the last element of the chain if it exists, None otherwise.
    */
-  def current(): T = chain.last
+  def current(): Option[T] = chain.lastOption
 
   /**
    * Retrieve the depth (length) of the chain.

--- a/legacy/src/main/scala/io/rhonix/rholang/normalizer/envimpl/NestingReaderImpl.scala
+++ b/legacy/src/main/scala/io/rhonix/rholang/normalizer/envimpl/NestingReaderImpl.scala
@@ -6,7 +6,7 @@ final case class NestingReaderImpl(
   patternInfo: HistoryChain[(Int, Boolean)],
   bundleInfo: HistoryChain[Boolean],
 ) extends NestingReader {
-  override def patternDepth: Int                     = patternInfo.current()._1
-  override def insideTopLevelReceivePattern: Boolean = patternInfo.current()._2
-  override def insideBundle: Boolean                 = bundleInfo.current()
+  override def patternDepth: Int                     = patternInfo.current().map(_._1).getOrElse(0)
+  override def insideTopLevelReceivePattern: Boolean = patternInfo.current().exists(_._2)
+  override def insideBundle: Boolean                 = bundleInfo.current().getOrElse(false)
 }

--- a/legacy/src/main/scala/io/rhonix/rholang/normalizer/envimpl/NestingWriterImpl.scala
+++ b/legacy/src/main/scala/io/rhonix/rholang/normalizer/envimpl/NestingWriterImpl.scala
@@ -11,7 +11,7 @@ final case class NestingWriterImpl[F[_]: Sync](
 ) extends NestingWriter[F] {
   override def withinPattern[R](inReceive: Boolean)(scopeFn: F[R]): F[R] =
     for {
-      incrementedDepth <- Sync[F].delay(patternInfo.current()._1 + 1)
+      incrementedDepth <- Sync[F].delay(patternInfo.current().map(_._1).getOrElse(0) + 1)
       fRes             <- patternInfo.runWithNewDataInChain(scopeFn, (incrementedDepth, inReceive))
     } yield fRes
 

--- a/legacy/src/main/scala/io/rhonix/rholang/normalizer/envimpl/VarMap.scala
+++ b/legacy/src/main/scala/io/rhonix/rholang/normalizer/envimpl/VarMap.scala
@@ -11,7 +11,7 @@ final case class VarMap[T](data: Map[String, VarContext[T]], nextIndex: Int) {
    *
    * @return Some(varContext) if the variable is found, None otherwise.
    */
-  def get(name: String): Option[VarContext[T]] = data.get(name).map(v => v.copy(indexRev = nextIndex - v.index - 1))
+  def get(name: String): Option[VarContext[T]] = data.get(name)
 
   /**
    * Adds a new variable to the map or update an existing one.
@@ -22,8 +22,7 @@ final case class VarMap[T](data: Map[String, VarContext[T]], nextIndex: Int) {
    * @return a new VarMap with the updated data and next index.
    */
   def put(name: String, sort: T, sourcePosition: SourcePosition): (VarMap[T], VarContext[T]) = {
-    // NOTE: Reverse index is not calculated here, it's temporary set to -1.
-    val varData  = VarContext(nextIndex, -1, sort, sourcePosition)
+    val varData  = VarContext(nextIndex, sort, sourcePosition)
     val newMap   = data.updated(name, varData)
     val newIndex = nextIndex + 1
     (VarMap(newMap, newIndex), varData)
@@ -38,7 +37,7 @@ final case class VarMap[T](data: Map[String, VarContext[T]], nextIndex: Int) {
   def create(vars: Seq[(T, SourcePosition)]): (VarMap[T], Seq[VarContext[T]]) = {
     val newNextIdx = nextIndex + vars.size
     // NOTE: Reverse index is not calculated here, it's temporary set to -1.
-    val addedVars  = vars.zipWithIndex.map { case ((t, pos), i) => VarContext(i + nextIndex, -1, t, pos) }
+    val addedVars  = vars.zipWithIndex.map { case ((t, pos), i) => VarContext(i + nextIndex, t, pos) }
     (copy(nextIndex = newNextIdx), addedVars)
   }
 }

--- a/legacy/src/main/scala/io/rhonix/rholang/normalizer/envimpl/VarMap.scala
+++ b/legacy/src/main/scala/io/rhonix/rholang/normalizer/envimpl/VarMap.scala
@@ -38,7 +38,7 @@ final case class VarMap[T](data: Map[String, VarContext[T]], nextIndex: Int) {
   def create(vars: Seq[(T, SourcePosition)]): (VarMap[T], Seq[VarContext[T]]) = {
     val newNextIdx = nextIndex + vars.size
     // NOTE: Reverse index is not calculated here, it's temporary set to -1.
-    val addedVars  = vars.zipWithIndex.map { case ((t, pos), i) => VarContext(i, -1, t, pos) }
+    val addedVars  = vars.zipWithIndex.map { case ((t, pos), i) => VarContext(i + nextIndex, -1, t, pos) }
     (copy(nextIndex = newNextIdx), addedVars)
   }
 }

--- a/legacy/src/main/scala/io/rhonix/rholang/normalizer/envimpl/VarMap.scala
+++ b/legacy/src/main/scala/io/rhonix/rholang/normalizer/envimpl/VarMap.scala
@@ -48,9 +48,9 @@ object VarMap {
   /**
    * Creates a default instance of VarMap.
    *
-   * @return a new VarMap with an empty data map and a next index of 0
+   * @return a new VarMap with an empty data map and given next index
    */
-  def default[T]: VarMap[T] = VarMap(Map[String, VarContext[T]](), 0)
+  def default[T](nextIndex: Int = 0): VarMap[T] = VarMap(Map[String, VarContext[T]](), nextIndex)
 
   /**
    * Create a VarMap with the given data.
@@ -58,7 +58,8 @@ object VarMap {
    * @param initData the data to initialize the VarMap with
    * @return a new VarMap with the given data and a next index of 0
    */
-  def apply[T](initData: Seq[(String, T, SourcePosition)]): VarMap[T] = initData.foldLeft(default[T]) {
-    case (varMap, data) => varMap.put(data._1, data._2, data._3)._1
-  }
+  def apply[T](initData: Seq[(String, T, SourcePosition)], nextIndex: Int = 0): VarMap[T] =
+    initData.foldLeft(default[T](nextIndex)) { case (varMap, data) =>
+      varMap.put(data._1, data._2, data._3)._1
+    }
 }

--- a/legacy/src/test/scala/coop/rchain/rholang/Resources.scala
+++ b/legacy/src/test/scala/coop/rchain/rholang/Resources.scala
@@ -3,13 +3,13 @@ package coop.rchain.rholang
 import cats.Parallel
 import cats.effect.kernel.Resource.ExitCase
 import cats.effect.{Async, Resource, Sync}
-import cats.syntax.all._
+import cats.syntax.all.*
 import com.typesafe.scalalogging.Logger
 import coop.rchain.metrics.{Metrics, Span}
 import coop.rchain.models.{BindPattern, ListParWithRandom, Par, TaggedContinuation}
 import coop.rchain.rholang.interpreter.RhoRuntime.{RhoHistoryRepository, RhoISpace}
 import coop.rchain.rholang.interpreter.SystemProcesses.Definition
-import coop.rchain.rholang.interpreter.{ReplayRhoRuntime, RhoRuntime, RholangCLI}
+import coop.rchain.rholang.interpreter.{MatchedParsWithRandom, ReplayRhoRuntime, RhoRuntime, RholangCLI}
 import coop.rchain.rspace
 import coop.rchain.rspace.RSpace.RSpaceStore
 import coop.rchain.rspace.syntax.rspaceSyntaxKeyValueStoreManager
@@ -25,35 +25,33 @@ object Resources {
   val logger: Logger = Logger(this.getClass.getName.stripSuffix("$"))
 
   def mkTempDir[F[_]: Sync](prefix: String): Resource[F, Path] =
-    Resource.makeCase(Sync[F].delay(Files.createTempDirectory(prefix)))(
-      (path, exitCase) =>
-        Sync[F].delay(exitCase match {
-          case ExitCase.Errored(ex) =>
-            logger
-              .error(
-                s"Exception thrown while using the tempDir '$path'. Temporary dir NOT deleted.",
-                ex
-              )
-          case _ => new Directory(new File(path.toString)).deleteRecursively()
-        })
+    Resource.makeCase(Sync[F].delay(Files.createTempDirectory(prefix)))((path, exitCase) =>
+      Sync[F].delay(exitCase match {
+        case ExitCase.Errored(ex) =>
+          logger
+            .error(
+              s"Exception thrown while using the tempDir '$path'. Temporary dir NOT deleted.",
+              ex,
+            )
+        case _                    => new Directory(new File(path.toString)).deleteRecursively()
+      }),
     )
 
-  def mkRhoISpace[F[_]: Async: Parallel: KeyValueStoreManager: Metrics: Span: Log]
-      : F[RhoISpace[F]] = {
+  def mkRhoISpace[F[_]: Async: Parallel: KeyValueStoreManager: Metrics: Span: Log]: F[RhoISpace[F]] = {
     import coop.rchain.rholang.interpreter.storage._
 
-    implicit val m: rspace.Match[F, BindPattern, ListParWithRandom] = matchListPar[F]
+    implicit val m: rspace.Match[F, BindPattern, ListParWithRandom, MatchedParsWithRandom] = matchListPar[F]
 
     for {
       store <- KeyValueStoreManager[F].rSpaceStores
-      space <- RSpace.create[F, Par, BindPattern, ListParWithRandom, TaggedContinuation](
-                store
-              )
+      space <- RSpace.create[F, Par, BindPattern, ListParWithRandom, TaggedContinuation, MatchedParsWithRandom](
+                 store,
+               )
     } yield space
   }
 
   def mkRuntime[F[_]: Async: Parallel: Metrics: Span: Log](
-      prefix: String
+    prefix: String,
   ): Resource[F, RhoRuntime[F]] =
     mkTempDir(prefix)
       .evalMap(RholangCLI.mkRSpaceStoreManager[F](_))
@@ -61,8 +59,8 @@ object Resources {
       .evalMap(RhoRuntime.createRuntime(_, Par()))
 
   def mkRuntimes[F[_]: Async: Parallel: Metrics: Span: Log](
-      prefix: String,
-      initRegistry: Boolean = false
+    prefix: String,
+    initRegistry: Boolean = false,
   ): Resource[F, (RhoRuntime[F], ReplayRhoRuntime[F], RhoHistoryRepository[F])] =
     mkTempDir(prefix)
       .evalMap(RholangCLI.mkRSpaceStoreManager[F](_))
@@ -70,22 +68,23 @@ object Resources {
       .evalMap(createRuntimes(_, initRegistry = initRegistry))
 
   def createRuntimes[F[_]: Async: Parallel: Log: Metrics: Span](
-      stores: RSpaceStore[F],
-      initRegistry: Boolean = false,
-      additionalSystemProcesses: Seq[Definition[F]] = Seq.empty
+    stores: RSpaceStore[F],
+    initRegistry: Boolean = false,
+    additionalSystemProcesses: Seq[Definition[F]] = Seq.empty,
   ): F[(RhoRuntime[F], ReplayRhoRuntime[F], RhoHistoryRepository[F])] = {
     import coop.rchain.rholang.interpreter.storage._
-    implicit val m: Match[F, BindPattern, ListParWithRandom] = matchListPar[F]
+    implicit val m: Match[F, BindPattern, ListParWithRandom, MatchedParsWithRandom] = matchListPar[F]
     for {
-      hrstores <- RSpace
-                   .createWithReplay[F, Par, BindPattern, ListParWithRandom, TaggedContinuation](
-                     stores
-                   )
-      (space, replay) = hrstores
-      runtimes <- RhoRuntime
-                   .createRuntimes[F](space, replay, initRegistry, additionalSystemProcesses, Par())
+      hrstores                <-
+        RSpace
+          .createWithReplay[F, Par, BindPattern, ListParWithRandom, TaggedContinuation, MatchedParsWithRandom](
+            stores,
+          )
+      (space, replay)          = hrstores
+      runtimes                <- RhoRuntime
+                                   .createRuntimes[F](space, replay, initRegistry, additionalSystemProcesses, Par())
       (runtime, replayRuntime) = runtimes
-      historyRepo              <- space.historyRepo
+      historyRepo             <- space.historyRepo
     } yield (runtime, replayRuntime, historyRepo)
   }
 

--- a/legacy/src/test/scala/coop/rchain/rholang/interpreter/PrettyPrinterTest.scala
+++ b/legacy/src/test/scala/coop/rchain/rholang/interpreter/PrettyPrinterTest.scala
@@ -93,26 +93,20 @@ class CollectPrinterSpec extends AnyFlatSpec with Matchers {
   }
 
   "List" should "Print" in {
-    val listData =
-      if (Normalizer.BOUND_VAR_INDEX_REVERSED)
-        Seq(BoundVarN(1), BoundVarN(0), GIntN(7))
-      else
-        Seq(BoundVarN(0), BoundVarN(1), GIntN(7))
-
-    val list   = EListN(listData, Some(FreeVarN(0)))
-    val result = PrettyPrinter(0, 2).buildString(list)
+    val listData = Seq(BoundVarN(0), BoundVarN(1), GIntN(7))
+    val list     = EListN(listData, Some(FreeVarN(0)))
+    val result   = PrettyPrinter(2).buildString(list)
     result shouldBe "[x0, x1, 7...free0]"
   }
 
   "Set" should "Print" in {
     val set    = ESetN(Seq(BoundVarN(0), BoundVarN(1), GIntN(7)), Some(FreeVarN(0)))
-    val result = PrettyPrinter(0, 2).buildString(set)
+    val result = PrettyPrinter(2).buildString(set)
     result shouldBe "Set(7, x0, x1...free0)"
   }
 
   "Map" should "Print" in {
-    val boundVars =
-      if (Normalizer.BOUND_VAR_INDEX_REVERSED) (BoundVarN(1), BoundVarN(0)) else (BoundVarN(0), BoundVarN(1))
+    val boundVars = (BoundVarN(0), BoundVarN(1))
 
     val map = EMapN(
       Seq(
@@ -122,7 +116,7 @@ class CollectPrinterSpec extends AnyFlatSpec with Matchers {
       Some(FreeVarN(0)),
     )
 
-    val result = PrettyPrinter(0, 2).buildString(map)
+    val result = PrettyPrinter(2).buildString(map)
     result shouldBe "{7 : \"" + "Seven" + "\", x0 : x1...free0}"
   }
 
@@ -488,7 +482,7 @@ class ProcPrinterSpec extends AnyFlatSpec with Matchers {
     // Add bound variable
     norm.boundVarWriter.putBoundVars(Seq(("x", ProcSort, SourcePosition(0, 0))))
 
-    val result = PrettyPrinter(0, 1).buildString(norm.normalize(pvar).value)
+    val result = PrettyPrinter(1).buildString(norm.normalize(pvar).value)
     result shouldBe "x0"
   }
 
@@ -513,7 +507,7 @@ class ProcPrinterSpec extends AnyFlatSpec with Matchers {
     norm.boundVarWriter.putBoundVars(Seq(("x", NameSort, SourcePosition(0, 0))))
 
     val pEval  = new PEval(new NameVar("x"))
-    val result = PrettyPrinter(0, 1).buildString(norm.normalize(pEval).value)
+    val result = PrettyPrinter(1).buildString(norm.normalize(pEval).value)
     result shouldBe "x0"
   }
 
@@ -525,7 +519,7 @@ class ProcPrinterSpec extends AnyFlatSpec with Matchers {
     val pEval  = new PEval(
       new NameQuote(new PPar(new PVar(new ProcVarVar("x")), new PVar(new ProcVarVar("x")))),
     )
-    val result = PrettyPrinter(0, 1).buildString(norm.normalize(pEval).value)
+    val result = PrettyPrinter(1).buildString(norm.normalize(pEval).value)
     result shouldBe
       """x0 |
         |x0""".stripMargin
@@ -585,7 +579,7 @@ class ProcPrinterSpec extends AnyFlatSpec with Matchers {
     sentData.add(new PGround(new GroundInt("7")))
     sentData.add(new PGround(new GroundInt("8")))
     val pSend    = new PSend(new NameVar("x"), new SendSingle(), sentData)
-    val result   = PrettyPrinter(0, 1).buildString(norm.normalize(pSend).value)
+    val result   = PrettyPrinter(1).buildString(norm.normalize(pSend).value)
     result shouldBe "@{x0}!(7, 8)"
   }
 
@@ -603,7 +597,7 @@ class ProcPrinterSpec extends AnyFlatSpec with Matchers {
     norm.boundVarWriter.putBoundVars(Seq(("x", ProcSort, SourcePosition(0, 0))))
 
     val parDoubleBound = new PPar(new PVar(new ProcVarVar("x")), new PVar(new ProcVarVar("x")))
-    val result         = PrettyPrinter(0, 1).buildString(norm.normalize(parDoubleBound).value)
+    val result         = PrettyPrinter(1).buildString(norm.normalize(parDoubleBound).value)
     result shouldBe
       """x0 |
         |x0""".stripMargin
@@ -924,7 +918,7 @@ class ProcPrinterSpec extends AnyFlatSpec with Matchers {
   "PMatches" should "display matches" in {
     val pMatches = new PMatches(new PGround(new GroundInt("1")), new PVar(new ProcVarWildcard()))
 
-    val result = PrettyPrinter(0, 1).buildString(testNormalizer.normalize(pMatches).value)
+    val result = PrettyPrinter(1).buildString(testNormalizer.normalize(pMatches).value)
 
     result shouldBe "(1 matches _)"
   }
@@ -990,7 +984,7 @@ class NamePrinterSpec extends AnyFlatSpec with Matchers {
     norm.boundVarWriter.putBoundVars(Seq(("x", NameSort, SourcePosition(0, 0))))
 
     val nvar   = new NameVar("x")
-    val result = PrettyPrinter(0, 1).buildString(norm.normalize(nvar).value)
+    val result = PrettyPrinter(1).buildString(norm.normalize(nvar).value)
     result shouldBe "x0"
   }
 
@@ -1000,7 +994,7 @@ class NamePrinterSpec extends AnyFlatSpec with Matchers {
     norm.boundVarWriter.putBoundVars(Seq(("x", NameSort, SourcePosition(0, 0))))
 
     val nqeval = new NameQuote(new PPar(new PEval(new NameVar("x")), new PEval(new NameVar("x"))))
-    val result = PrettyPrinter(0, 1).buildString(norm.normalize(nqeval).value)
+    val result = PrettyPrinter(1).buildString(norm.normalize(nqeval).value)
     result shouldBe "x0 |\nx0"
   }
 }

--- a/legacy/src/test/scala/coop/rchain/rholang/interpreter/PrettyPrinterTest.scala
+++ b/legacy/src/test/scala/coop/rchain/rholang/interpreter/PrettyPrinterTest.scala
@@ -107,7 +107,7 @@ class CollectPrinterSpec extends AnyFlatSpec with Matchers {
   "Set" should "Print" in {
     val set    = ESetN(Seq(BoundVarN(0), BoundVarN(1), GIntN(7)), Some(FreeVarN(0)))
     val result = PrettyPrinter(0, 2).buildString(set)
-    result shouldBe "Set(7, x1, x0...free0)"
+    result shouldBe "Set(7, x0, x1...free0)"
   }
 
   "Map" should "Print" in {

--- a/legacy/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
+++ b/legacy/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
@@ -669,7 +669,7 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
           freeCount = 3,
         ),
         ReceiveBind(
-          Seq(EVar(FreeVar(0)), EVar(FreeVar(1)), EVar(FreeVar(2))),
+          Seq(EVar(FreeVar(3)), EVar(FreeVar(4)), EVar(FreeVar(5))),
           GString("channel2"),
           freeCount = 3,
         ),

--- a/legacy/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
+++ b/legacy/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
@@ -612,8 +612,8 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
           .withConnectiveUsed(true)
       val sendTarget   =
         Send(
-          EVar(BoundVar(1)),
-          List(GInt(7L), EVar(BoundVar(0))),
+          EVar(BoundVar(0)),
+          List(GInt(7L), EVar(BoundVar(1))),
           persistent = false,
           BitSet(0, 1),
         )
@@ -624,7 +624,7 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
             pattern,
             Send(
               GString("result"),
-              List(EVar(BoundVar(1)), EVar(BoundVar(0))),
+              List(EVar(BoundVar(0)), EVar(BoundVar(1))),
               false,
               BitSet(0, 1),
             ),
@@ -864,7 +864,7 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
             List(
               Datum.create(
                 channel0,
-                ListParWithRandom(Seq(GPrivate(ByteString.copyFrom(Array[Byte](42)))), result0Rand),
+                ListParWithRandom(Seq(GPrivate(ByteString.copyFrom(chosenName))), result0Rand),
                 persist = false)),
             List()),
         List(channel1) ->
@@ -872,7 +872,7 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
             List(
               Datum.create(
                 channel1,
-                ListParWithRandom(Seq(GPrivate(ByteString.copyFrom(chosenName))), result1Rand),
+                ListParWithRandom(Seq(GPrivate(ByteString.copyFrom(Array[Byte](42)))), result1Rand),
                 persist = false)),
             List())
       )

--- a/legacy/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
+++ b/legacy/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
@@ -38,41 +38,40 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
 
   private[this] def mapData(elements: Map[Par, (Seq[Par], Blake2b512Random)]): Iterable[
     (
-        Seq[Par],
-        Row[BindPattern, ListParWithRandom, TaggedContinuation]
-    )
+      Seq[Par],
+      Row[BindPattern, ListParWithRandom, TaggedContinuation],
+    ),
   ] =
     mapDataEntries(elements.view.mapValues { case (data, rand) => DataMapEntry(data, rand) }.toMap)
 
   private[this] def mapDataEntries(elements: Map[Par, DataMapEntry]): Iterable[
     (
-        Seq[Par],
-        Row[BindPattern, ListParWithRandom, TaggedContinuation]
-    )
+      Seq[Par],
+      Row[BindPattern, ListParWithRandom, TaggedContinuation],
+    ),
   ] =
-    elements.map {
-      case (channel, entry) =>
-        Seq(channel) ->
-          Row[BindPattern, ListParWithRandom, TaggedContinuation](
-            List(
-              Datum.create(
-                channel,
-                ListParWithRandom(
-                  entry.data,
-                  entry.rand
-                ),
-                false
-              )
+    elements.map { case (channel, entry) =>
+      Seq(channel) ->
+        Row[BindPattern, ListParWithRandom, TaggedContinuation](
+          List(
+            Datum.create(
+              channel,
+              ListParWithRandom(
+                entry.data,
+                entry.rand,
+              ),
+              false,
             ),
-            List.empty
-          )
+          ),
+          List.empty,
+        )
     }.toSeq
 
   private[this] def checkContinuation(
-      result: Map[
-        Seq[Par],
-        Row[BindPattern, ListParWithRandom, TaggedContinuation]
-      ]
+    result: Map[
+      Seq[Par],
+      Row[BindPattern, ListParWithRandom, TaggedContinuation],
+    ],
   )(channels: List[Par], bindPatterns: List[BindPattern], body: ParWithRandom): Assertion =
     result should be(
       HashMap(
@@ -85,20 +84,19 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
                 bindPatterns,
                 TaggedContinuation(ParBody(body)),
                 persist = false,
-                SortedSet.empty
-              )
-            )
-          )
-      )
+                SortedSet.empty,
+              ),
+            ),
+          ),
+      ),
     )
 
   "evalExpr" should "handle simple addition" in {
-    val result = withTestSpace {
-      case TestFixture(_, reducer) =>
-        val addExpr      = EPlus(GInt(7L), GInt(8L))
-        implicit val env = Env[Par]()
-        val resultTask   = reducer.evalExpr(addExpr)
-        Await.result(resultTask.unsafeToFuture(), 3.seconds)
+    val result = withTestSpace { case TestFixture(_, reducer) =>
+      val addExpr      = EPlus(GInt(7L), GInt(8L))
+      implicit val env = Env[Par]()
+      val resultTask   = reducer.evalExpr(addExpr)
+      Await.result(resultTask.unsafeToFuture(), 3.seconds)
     }
 
     val expected = Seq(Expr(GInt(15L)))
@@ -106,12 +104,11 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
   }
 
   "evalExpr" should "handle long addition" in {
-    val result = withTestSpace {
-      case TestFixture(_, reducer) =>
-        val addExpr      = EPlus(GInt(Int.MaxValue), GInt(Int.MaxValue))
-        implicit val env = Env[Par]()
-        val resultTask   = reducer.evalExpr(addExpr)
-        Await.result(resultTask.unsafeToFuture(), 3.seconds)
+    val result = withTestSpace { case TestFixture(_, reducer) =>
+      val addExpr      = EPlus(GInt(Int.MaxValue), GInt(Int.MaxValue))
+      implicit val env = Env[Par]()
+      val resultTask   = reducer.evalExpr(addExpr)
+      Await.result(resultTask.unsafeToFuture(), 3.seconds)
     }
 
     val expected = Seq(Expr(GInt(2 * Int.MaxValue.toLong)))
@@ -119,12 +116,11 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
   }
 
   "evalExpr" should "leave ground values alone" in {
-    val result = withTestSpace {
-      case TestFixture(_, reducer) =>
-        val groundExpr   = GInt(7L)
-        implicit val env = Env[Par]()
-        val resultTask   = reducer.evalExpr(groundExpr)
-        Await.result(resultTask.unsafeToFuture(), 3.seconds)
+    val result = withTestSpace { case TestFixture(_, reducer) =>
+      val groundExpr   = GInt(7L)
+      implicit val env = Env[Par]()
+      val resultTask   = reducer.evalExpr(groundExpr)
+      Await.result(resultTask.unsafeToFuture(), 3.seconds)
     }
 
     val expected = Seq(Expr(GInt(7L)))
@@ -132,24 +128,22 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
   }
 
   "evalExpr" should "handle equality between arbitary processes" in {
-    val result = withTestSpace {
-      case TestFixture(_, reducer) =>
-        val eqExpr       = EEq(GPrivateBuilder("private_name"), GPrivateBuilder("private_name"))
-        implicit val env = Env[Par]()
-        val resultTask   = reducer.evalExpr(eqExpr)
-        Await.result(resultTask.unsafeToFuture(), 3.seconds)
+    val result   = withTestSpace { case TestFixture(_, reducer) =>
+      val eqExpr       = EEq(GPrivateBuilder("private_name"), GPrivateBuilder("private_name"))
+      implicit val env = Env[Par]()
+      val resultTask   = reducer.evalExpr(eqExpr)
+      Await.result(resultTask.unsafeToFuture(), 3.seconds)
     }
     val expected = Seq(Expr(GBool(true)))
     result.exprs should be(expected)
   }
 
   "evalExpr" should "substitute before comparison." in {
-    val result = withTestSpace {
-      case TestFixture(_, reducer) =>
-        implicit val emptyEnv = Env.makeEnv(Par(), Par())
-        val eqExpr            = EEq(EVar(BoundVar(0)), EVar(BoundVar(1)))
-        val resultTask        = reducer.evalExpr(eqExpr)
-        Await.result(resultTask.unsafeToFuture(), 3.seconds)
+    val result   = withTestSpace { case TestFixture(_, reducer) =>
+      implicit val emptyEnv = Env.makeEnv(Par(), Par())
+      val eqExpr            = EEq(EVar(BoundVar(0)), EVar(BoundVar(1)))
+      val resultTask        = reducer.evalExpr(eqExpr)
+      Await.result(resultTask.unsafeToFuture(), 3.seconds)
     }
     val expected = Seq(Expr(GBool(true)))
     result.exprs should be(expected)
@@ -158,23 +152,22 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
   "eval of Bundle" should "evaluate contents of bundle" in {
     val splitRand    = rand.splitByte(0)
     val channel: Par = GString("channel")
-    val result = withTestSpace {
-      case TestFixture(space, reducer) =>
-        val bundleSend =
-          Bundle(Send(channel, List(GInt(7L), GInt(8L), GInt(9L)), persistent = false, BitSet()))
-        implicit val env = Env[Par]()
-        val resultTask   = reducer.eval(bundleSend)(env, splitRand)
-        val inspectTask = for {
-          _   <- resultTask
-          res <- space.toMap
-        } yield res
-        Await.result(inspectTask.unsafeToFuture(), 3.seconds)
+    val result       = withTestSpace { case TestFixture(space, reducer) =>
+      val bundleSend   =
+        Bundle(Send(channel, List(GInt(7L), GInt(8L), GInt(9L)), persistent = false, BitSet()))
+      implicit val env = Env[Par]()
+      val resultTask   = reducer.eval(bundleSend)(env, splitRand)
+      val inspectTask  = for {
+        _   <- resultTask
+        res <- space.toMap
+      } yield res
+      Await.result(inspectTask.unsafeToFuture(), 3.seconds)
     }
 
     val expectedResult = mapData(
       Map(
-        channel -> ((Seq(GInt(7L), GInt(8L), GInt(9L)), splitRand))
-      )
+        channel -> ((Seq(GInt(7L), GInt(8L), GInt(9L)), splitRand)),
+      ),
     )
     result.toSeq should contain theSameElementsAs expectedResult.toSeq
   }
@@ -182,32 +175,30 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
   it should "throw an error if names are used against their polarity" in {
     /* for (n <- @bundle+ { y } ) { }  -> for (n <- y) { }
      */
-    val y = GString("y")
+    val y       = GString("y")
     val receive = Receive(
       Seq(ReceiveBind(Seq(Par()), Bundle(y, writeFlag = true))),
-      Par()
+      Par(),
     )
 
-    val receiveResult = withTestSpace {
-      case TestFixture(space, reducer) =>
-        implicit val env = Env[Par]()
-        val task         = reducer.eval(receive) >> space.toMap
-        Await.ready(task.unsafeToFuture(), 3.seconds)
+    val receiveResult = withTestSpace { case TestFixture(space, reducer) =>
+      implicit val env = Env[Par]()
+      val task         = reducer.eval(receive) >> space.toMap
+      Await.ready(task.unsafeToFuture(), 3.seconds)
     }
     receiveResult.value shouldBe Failure(ReduceError("Trying to read from non-readable channel.")).some
 
     /* @bundle- { x } !(7) -> x!(7)
      */
-    val x = GString("channel")
+    val x    = GString("channel")
     val send =
       Send(Bundle(x, writeFlag = false, readFlag = true), Seq(Expr(GInt(7L))))
 
-    val sendResult = withTestSpace {
-      case TestFixture(space, reducer) =>
-        implicit val env = Env[Par]()
+    val sendResult = withTestSpace { case TestFixture(space, reducer) =>
+      implicit val env = Env[Par]()
 
-        val task = reducer.eval(send) >> space.toMap
-        Await.ready(task.unsafeToFuture(), 3.seconds)
+      val task = reducer.eval(send) >> space.toMap
+      Await.ready(task.unsafeToFuture(), 3.seconds)
     }
     sendResult.value shouldBe Failure(ReduceError("Trying to send on non-writeable channel.")).some
   }
@@ -215,46 +206,44 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
   "eval of Send" should "place something in the tuplespace." in {
     val channel: Par = GString("channel")
     val splitRand    = rand.splitByte(0)
-    val result = withTestSpace {
-      case TestFixture(space, reducer) =>
-        val send =
-          Send(channel, List(GInt(7L), GInt(8L), GInt(9L)), false, BitSet())
-        implicit val env = Env[Par]()
-        val resultTask   = reducer.eval(send)(env, splitRand)
-        val inspectTask = for {
-          _   <- resultTask
-          res <- space.toMap
-        } yield res
-        Await.result(inspectTask.unsafeToFuture(), 3.seconds)
+    val result       = withTestSpace { case TestFixture(space, reducer) =>
+      val send         =
+        Send(channel, List(GInt(7L), GInt(8L), GInt(9L)), false, BitSet())
+      implicit val env = Env[Par]()
+      val resultTask   = reducer.eval(send)(env, splitRand)
+      val inspectTask  = for {
+        _   <- resultTask
+        res <- space.toMap
+      } yield res
+      Await.result(inspectTask.unsafeToFuture(), 3.seconds)
     }
 
     val expectedResult = mapData(
       Map(
-        channel -> ((Seq(GInt(7L), GInt(8L), GInt(9L)), splitRand))
-      )
+        channel -> ((Seq(GInt(7L), GInt(8L), GInt(9L)), splitRand)),
+      ),
     )
     result.toSeq should contain theSameElementsAs expectedResult.toSeq
   }
 
   it should "verify that Bundle is writeable before sending on Bundle " in {
-    val splitRand = rand.splitByte(0)
+    val splitRand    = rand.splitByte(0)
     /* @bundle+ { x } !(7) -> x!(7)
      */
     val channel: Par = GString("channel")
-    val send =
+    val send         =
       Send(Bundle(channel, writeFlag = true), Seq(Expr(GInt(7L))))
 
-    val result = withTestSpace {
-      case TestFixture(space, reducer) =>
-        implicit val env = Env[Par]()
-        val task         = reducer.eval(send)(env, splitRand).flatMap(_ => space.toMap)
-        Await.result(task.unsafeToFuture(), 3.seconds)
+    val result = withTestSpace { case TestFixture(space, reducer) =>
+      implicit val env = Env[Par]()
+      val task         = reducer.eval(send)(env, splitRand).flatMap(_ => space.toMap)
+      Await.result(task.unsafeToFuture(), 3.seconds)
     }
 
     val expectedResult = mapData(
       Map(
-        channel -> ((Seq(GInt(7L)), splitRand))
-      )
+        channel -> ((Seq(GInt(7L)), splitRand)),
+      ),
     )
     result.toSeq should contain theSameElementsAs expectedResult.toSeq
   }
@@ -262,37 +251,36 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
   "eval of single channel Receive" should "place something in the tuplespace." in {
     val splitRand    = rand.splitByte(0)
     val channel: Par = GString("channel")
-    val result = withTestSpace {
-      case TestFixture(space, reducer) =>
-        val receive =
-          Receive(
-            Seq(
-              ReceiveBind(
-                Seq(EVar(FreeVar(0)), EVar(FreeVar(1)), EVar(FreeVar(2))),
-                channel
-              )
+    val result       = withTestSpace { case TestFixture(space, reducer) =>
+      val receive      =
+        Receive(
+          Seq(
+            ReceiveBind(
+              Seq(EVar(FreeVar(0)), EVar(FreeVar(1)), EVar(FreeVar(2))),
+              channel,
             ),
-            Par(),
-            false,
-            false,
-            3,
-            BitSet()
-          )
-        implicit val env = Env[Par]()
-        val resultTask   = reducer.eval(receive)(env, splitRand)
-        val inspectTask = for {
-          _   <- resultTask
-          res <- space.toMap
-        } yield res
-        Await.result(inspectTask.unsafeToFuture(), 3.seconds)
+          ),
+          Par(),
+          false,
+          false,
+          3,
+          BitSet(),
+        )
+      implicit val env = Env[Par]()
+      val resultTask   = reducer.eval(receive)(env, splitRand)
+      val inspectTask  = for {
+        _   <- resultTask
+        res <- space.toMap
+      } yield res
+      Await.result(inspectTask.unsafeToFuture(), 3.seconds)
     }
-    val bindPattern = BindPattern(
+    val bindPattern  = BindPattern(
       List(
         EVar(FreeVar(0)),
         EVar(FreeVar(1)),
-        EVar(FreeVar(2))
+        EVar(FreeVar(2)),
       ),
-      None
+      None,
     )
     checkContinuation(result)(List(channel), List(bindPattern), ParWithRandom(Par(), splitRand))
   }
@@ -302,82 +290,79 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
     /* for (@Nil <- @bundle- { y } ) { }  -> for (n <- y) { }
      */
 
-    val y = GString("y")
+    val y       = GString("y")
     val receive = Receive(
       binds = Seq(
         ReceiveBind(
           patterns = Seq(Par()),
-          source = Bundle(y, readFlag = true)
-        )
+          source = Bundle(y, readFlag = true),
+        ),
       ),
-      body = Par()
+      body = Par(),
     )
 
-    val result = withTestSpace {
-      case TestFixture(space, reducer) =>
-        implicit val env = Env[Par]()
-        val task         = reducer.eval(receive)(env, splitRand).flatMap(_ => space.toMap)
-        Await.result(task.unsafeToFuture(), 3.seconds)
+    val result = withTestSpace { case TestFixture(space, reducer) =>
+      implicit val env = Env[Par]()
+      val task         = reducer.eval(receive)(env, splitRand).flatMap(_ => space.toMap)
+      Await.result(task.unsafeToFuture(), 3.seconds)
     }
 
     val channels = List[Par](y)
     checkContinuation(result)(
       channels,
       List(BindPattern(List(Par()), None)),
-      ParWithRandom(Par(), splitRand)
+      ParWithRandom(Par(), splitRand),
     )
   }
 
   "eval of Send | Receive" should "meet in the tuplespace and proceed." in {
-    val splitRand0 = rand.splitByte(0)
-    val splitRand1 = rand.splitByte(1)
-    val mergeRand  = Blake2b512Random.merge(Seq(splitRand1, splitRand0))
-    val send =
+    val splitRand0      = rand.splitByte(0)
+    val splitRand1      = rand.splitByte(1)
+    val mergeRand       = Blake2b512Random.merge(Seq(splitRand1, splitRand0))
+    val send            =
       Send(GString("channel"), List(GInt(7L), GInt(8L), GInt(9L)), persistent = false, BitSet())
-    val receive = Receive(
+    val receive         = Receive(
       Seq(
         ReceiveBind(
           Seq(EVar(FreeVar(0)), EVar(FreeVar(1)), EVar(FreeVar(2))),
           GString("channel"),
-          freeCount = 3
-        )
+          freeCount = 3,
+        ),
       ),
       Send(GString("result"), List(GString("Success")), persistent = false, BitSet()),
       persistent = false,
       peek = false,
       3,
-      BitSet()
+      BitSet(),
     )
-    val sendFirstResult = withTestSpace {
-      case TestFixture(space, reducer) =>
-        implicit val env = Env[Par]()
-        val inspectTaskSendFirst = for {
-          _   <- reducer.eval(send)(env, splitRand0)
-          _   <- reducer.eval(receive)(env, splitRand1)
-          res <- space.toMap
-        } yield res
-        Await.result(inspectTaskSendFirst.unsafeToFuture(), 3.seconds)
+    val sendFirstResult = withTestSpace { case TestFixture(space, reducer) =>
+      implicit val env         = Env[Par]()
+      val inspectTaskSendFirst = for {
+        _   <- reducer.eval(send)(env, splitRand0)
+        _   <- reducer.eval(receive)(env, splitRand1)
+        res <- space.toMap
+      } yield res
+      Await.result(inspectTaskSendFirst.unsafeToFuture(), 3.seconds)
     }
 
     val channel: Par = GString("result")
 
     val expectedResult = mapData(
       Map(
-        channel -> ((Seq(GString("Success")), mergeRand))
-      )
+        channel -> ((Seq(GString("Success")), mergeRand)),
+      ),
     )
 
     sendFirstResult.toSeq should contain theSameElementsAs expectedResult.toSeq
 
-    val receiveFirstResult = withTestSpace {
-      case TestFixture(space, reducer) =>
-        implicit val env = Env[Par]()
-        val inspectTaskReceiveFirst = for {
-          _   <- reducer.eval(receive)(env, splitRand1)
-          _   <- reducer.eval(send)(env, splitRand0)
-          res <- space.toMap
-        } yield res
-        Await.result(inspectTaskReceiveFirst.unsafeToFuture(), 3.seconds)
+    val receiveFirstResult = withTestSpace { case TestFixture(space, reducer) =>
+      implicit val env            = Env[Par]()
+      val inspectTaskReceiveFirst = for {
+        _   <- reducer.eval(receive)(env, splitRand1)
+        _   <- reducer.eval(send)(env, splitRand0)
+        res <- space.toMap
+      } yield res
+      Await.result(inspectTaskReceiveFirst.unsafeToFuture(), 3.seconds)
     }
 
     receiveFirstResult.toSeq should contain theSameElementsAs expectedResult.toSeq
@@ -390,50 +375,48 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
     val splitRand0 = rand.splitByte(0)
     val splitRand1 = rand.splitByte(1)
     val mergeRand  = Blake2b512Random.merge(Seq(splitRand1, splitRand0))
-    val send =
+    val send       =
       Send(channel, List(GInt(7L), GInt(8L), GInt(9L)), false, BitSet())
-    val receive = Receive(
+    val receive    = Receive(
       Seq(
         ReceiveBind(
           Seq(EVar(FreeVar(0)), EVar(FreeVar(1)), EVar(FreeVar(2))),
           channel,
-          freeCount = 3
-        )
+          freeCount = 3,
+        ),
       ),
       Send(resultChannel, List(GString("Success")), false, BitSet()),
       false,
       true,
       3,
-      BitSet()
+      BitSet(),
     )
 
     val expectedResult = mapDataEntries(
       Map(
         channel       -> (DataMapEntry(Seq(GInt(7L), GInt(8L), GInt(9L)), splitRand0)),
-        resultChannel -> (DataMapEntry(Seq(GString("Success")), mergeRand))
-      )
+        resultChannel -> (DataMapEntry(Seq(GString("Success")), mergeRand)),
+      ),
     )
 
-    val sendFirstResult = fixture {
-      case (space, reducer) =>
-        implicit val env = Env[Par]()
-        for {
-          _   <- reducer.eval(send)(env, splitRand0)
-          _   <- reducer.eval(receive)(env, splitRand1)
-          res <- space.toMap
-        } yield res
+    val sendFirstResult = fixture { case (space, reducer) =>
+      implicit val env = Env[Par]()
+      for {
+        _   <- reducer.eval(send)(env, splitRand0)
+        _   <- reducer.eval(receive)(env, splitRand1)
+        res <- space.toMap
+      } yield res
     }
 
     sendFirstResult.toSeq should contain theSameElementsAs expectedResult.toSeq
 
-    val receiveFirstResult = fixture {
-      case (space, reducer) =>
-        implicit val env = Env[Par]()
-        for {
-          _   <- reducer.eval(receive)(env, splitRand1)
-          _   <- reducer.eval(send)(env, splitRand0)
-          res <- space.toMap
-        } yield res
+    val receiveFirstResult = fixture { case (space, reducer) =>
+      implicit val env = Env[Par]()
+      for {
+        _   <- reducer.eval(receive)(env, splitRand1)
+        _   <- reducer.eval(send)(env, splitRand0)
+        res <- space.toMap
+      } yield res
     }
 
     receiveFirstResult.toSeq should contain theSameElementsAs expectedResult.toSeq
@@ -441,9 +424,9 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
 
   "eval of Send | Receive" should "when whole list is bound to list remainder, meet in the tuplespace and proceed. (RHOL-422)" in {
     // for(@[...a] <- @"channel") { … } | @"channel"!([7,8,9])
-    val splitRand0 = rand.splitByte(0)
-    val splitRand1 = rand.splitByte(1)
-    val mergeRand  = Blake2b512Random.merge(Seq(splitRand1, splitRand0))
+    val splitRand0      = rand.splitByte(0)
+    val splitRand1      = rand.splitByte(1)
+    val mergeRand       = Blake2b512Random.merge(Seq(splitRand1, splitRand0))
     // format: off
     val send =
       Send(GString("channel"), List(Par(exprs = Seq(Expr(EListBody(EList(Seq(GInt(7L), GInt(8L), GInt(9L)))))))), persistent = false, BitSet())
@@ -459,34 +442,32 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
       BitSet()
     )
     // format: on
-    val sendFirstResult = withTestSpace {
-      case TestFixture(space, reducer) =>
-        implicit val env = Env[Par]()
-        val inspectTaskSendFirst = for {
-          _   <- reducer.eval(send)(env, splitRand0)
-          _   <- reducer.eval(receive)(env, splitRand1)
-          res <- space.toMap
-        } yield res
-        Await.result(inspectTaskSendFirst.unsafeToFuture(), 3.seconds)
+    val sendFirstResult = withTestSpace { case TestFixture(space, reducer) =>
+      implicit val env         = Env[Par]()
+      val inspectTaskSendFirst = for {
+        _   <- reducer.eval(send)(env, splitRand0)
+        _   <- reducer.eval(receive)(env, splitRand1)
+        res <- space.toMap
+      } yield res
+      Await.result(inspectTaskSendFirst.unsafeToFuture(), 3.seconds)
     }
 
-    val channel: Par = GString("result")
+    val channel: Par   = GString("result")
     val expectedResult = mapData(
       Map(
-        channel -> ((Seq(GString("Success")), mergeRand))
-      )
+        channel -> ((Seq(GString("Success")), mergeRand)),
+      ),
     )
     sendFirstResult.toSeq should contain theSameElementsAs expectedResult.toSeq
 
-    val receiveFirstResult = withTestSpace {
-      case TestFixture(space, reducer) =>
-        implicit val env = Env[Par]()
-        val inspectTaskReceiveFirst = for {
-          _   <- reducer.eval(receive)(env, splitRand1)
-          _   <- reducer.eval(send)(env, splitRand0)
-          res <- space.toMap
-        } yield res
-        Await.result(inspectTaskReceiveFirst.unsafeToFuture(), 3.seconds)
+    val receiveFirstResult = withTestSpace { case TestFixture(space, reducer) =>
+      implicit val env            = Env[Par]()
+      val inspectTaskReceiveFirst = for {
+        _   <- reducer.eval(receive)(env, splitRand1)
+        _   <- reducer.eval(send)(env, splitRand0)
+        res <- space.toMap
+      } yield res
+      Await.result(inspectTaskReceiveFirst.unsafeToFuture(), 3.seconds)
     }
 
     receiveFirstResult.toSeq should contain theSameElementsAs expectedResult.toSeq
@@ -496,93 +477,90 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
     val splitRand0 = rand.splitByte(0)
     val splitRand1 = rand.splitByte(1)
     val mergeRand  = Blake2b512Random.merge(Seq(splitRand1, splitRand0))
-    val send =
+    val send       =
       Send(
         EPlus(GInt(7L), GInt(8L)),
         List(GInt(7L), GInt(8L), GInt(9L)),
         persistent = false,
-        BitSet()
+        BitSet(),
       )
-    val receive = Receive(
+    val receive    = Receive(
       Seq(
         ReceiveBind(
           Seq(EVar(FreeVar(0)), EVar(FreeVar(1)), EVar(FreeVar(2))),
           GInt(15L),
-          freeCount = 3
-        )
+          freeCount = 3,
+        ),
       ),
       Send(GString("result"), List(GString("Success")), persistent = false, BitSet()),
       persistent = false,
       peek = false,
       3,
-      BitSet()
+      BitSet(),
     )
 
-    val sendFirstResult = withTestSpace {
-      case TestFixture(space, reducer) =>
-        implicit val env = Env[Par]()
-        val inspectTaskSendFirst = for {
-          _   <- reducer.eval(send)(env, splitRand0)
-          _   <- reducer.eval(receive)(env, splitRand1)
-          res <- space.toMap
-        } yield res
-        Await.result(inspectTaskSendFirst.unsafeToFuture(), 3.seconds)
+    val sendFirstResult = withTestSpace { case TestFixture(space, reducer) =>
+      implicit val env         = Env[Par]()
+      val inspectTaskSendFirst = for {
+        _   <- reducer.eval(send)(env, splitRand0)
+        _   <- reducer.eval(receive)(env, splitRand1)
+        res <- space.toMap
+      } yield res
+      Await.result(inspectTaskSendFirst.unsafeToFuture(), 3.seconds)
     }
 
-    val channel: Par = GString("result")
+    val channel: Par   = GString("result")
     val expectedResult = mapData(
       Map(
-        channel -> ((Seq(GString("Success")), mergeRand))
-      )
+        channel -> ((Seq(GString("Success")), mergeRand)),
+      ),
     )
     sendFirstResult.toSeq should contain theSameElementsAs expectedResult.toSeq
 
-    val receiveFirstResult = withTestSpace {
-      case TestFixture(space, reducer) =>
-        implicit val env = Env[Par]()
-        val inspectTaskReceiveFirst = for {
-          _   <- reducer.eval(receive)(env, splitRand1)
-          _   <- reducer.eval(send)(env, splitRand0)
-          res <- space.toMap
-        } yield res
-        Await.result(inspectTaskReceiveFirst.unsafeToFuture(), 3.seconds)
+    val receiveFirstResult = withTestSpace { case TestFixture(space, reducer) =>
+      implicit val env            = Env[Par]()
+      val inspectTaskReceiveFirst = for {
+        _   <- reducer.eval(receive)(env, splitRand1)
+        _   <- reducer.eval(send)(env, splitRand0)
+        res <- space.toMap
+      } yield res
+      Await.result(inspectTaskReceiveFirst.unsafeToFuture(), 3.seconds)
     }
     receiveFirstResult.toSeq should contain theSameElementsAs expectedResult.toSeq
   }
 
   "eval of Send of Receive | Receive" should "meet in the tuplespace and proceed." in {
-    val baseRand   = rand.splitByte(2)
-    val splitRand0 = baseRand.splitByte(0)
-    val splitRand1 = baseRand.splitByte(1)
-    val mergeRand  = Blake2b512Random.merge(Seq(splitRand1, splitRand0))
+    val baseRand      = rand.splitByte(2)
+    val splitRand0    = baseRand.splitByte(0)
+    val splitRand1    = baseRand.splitByte(1)
+    val mergeRand     = Blake2b512Random.merge(Seq(splitRand1, splitRand0))
     val simpleReceive = Receive(
       Seq(ReceiveBind(Seq(GInt(2L)), GInt(2L))),
       Par(),
       persistent = false,
       peek = false,
       0,
-      BitSet()
+      BitSet(),
     )
-    val send =
+    val send          =
       Send(GInt(1L), Seq[Par](simpleReceive), persistent = false, BitSet())
-    val receive = Receive(
+    val receive       = Receive(
       Seq(ReceiveBind(Seq(EVar(FreeVar(0))), GInt(1L), freeCount = 1)),
       EVar(BoundVar(0)),
       persistent = false,
       peek = false,
       1,
-      BitSet()
+      BitSet(),
     )
 
-    val sendFirstResult = withTestSpace {
-      case TestFixture(space, reducer) =>
-        implicit val env = Env[Par]()
-        val inspectTaskSendFirst = for {
-          _   <- reducer.eval(send)(env, splitRand0)
-          _   <- reducer.eval(receive)(env, splitRand1)
-          res <- space.toMap
-        } yield res
-        Await.result(inspectTaskSendFirst.unsafeToFuture(), 3.seconds)
+    val sendFirstResult = withTestSpace { case TestFixture(space, reducer) =>
+      implicit val env         = Env[Par]()
+      val inspectTaskSendFirst = for {
+        _   <- reducer.eval(send)(env, splitRand0)
+        _   <- reducer.eval(receive)(env, splitRand1)
+        res <- space.toMap
+      } yield res
+      Await.result(inspectTaskSendFirst.unsafeToFuture(), 3.seconds)
     }
 
     val channels = List[Par](GInt(2L))
@@ -591,163 +569,157 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
     checkContinuation(sendFirstResult)(
       channels,
       List(BindPattern(List(GInt(2L)))),
-      ParWithRandom(Par(), mergeRand)
+      ParWithRandom(Par(), mergeRand),
     )
 
-    val receiveFirstResult = withTestSpace {
-      case TestFixture(space, reducer) =>
-        implicit val env = Env[Par]()
-        val inspectTaskReceiveFirst = for {
-          _   <- reducer.eval(receive)(env, splitRand1)
-          _   <- reducer.eval(send)(env, splitRand0)
-          res <- space.toMap
-        } yield res
-        Await.result(inspectTaskReceiveFirst.unsafeToFuture(), 3.seconds)
+    val receiveFirstResult = withTestSpace { case TestFixture(space, reducer) =>
+      implicit val env            = Env[Par]()
+      val inspectTaskReceiveFirst = for {
+        _   <- reducer.eval(receive)(env, splitRand1)
+        _   <- reducer.eval(send)(env, splitRand0)
+        res <- space.toMap
+      } yield res
+      Await.result(inspectTaskReceiveFirst.unsafeToFuture(), 3.seconds)
     }
 
     checkContinuation(receiveFirstResult)(
       channels,
       List(BindPattern(List(GInt(2L)))),
-      ParWithRandom(Par(), mergeRand)
+      ParWithRandom(Par(), mergeRand),
     )
 
-    val bothResult = withTestSpace {
-      case TestFixture(space, reducer) =>
-        implicit val env = Env[Par]()
-        val inspectTaskReceiveFirst = for {
-          _   <- reducer.eval(Par(receives = Seq(receive), sends = Seq(send)))(env, baseRand)
-          res <- space.toMap
-        } yield res
-        Await.result(inspectTaskReceiveFirst.unsafeToFuture(), 3.seconds)
+    val bothResult = withTestSpace { case TestFixture(space, reducer) =>
+      implicit val env            = Env[Par]()
+      val inspectTaskReceiveFirst = for {
+        _   <- reducer.eval(Par(receives = Seq(receive), sends = Seq(send)))(env, baseRand)
+        res <- space.toMap
+      } yield res
+      Await.result(inspectTaskReceiveFirst.unsafeToFuture(), 3.seconds)
     }
 
     checkContinuation(bothResult)(
       channels,
       List(BindPattern(List(GInt(2L)))),
-      ParWithRandom(Par(), mergeRand)
+      ParWithRandom(Par(), mergeRand),
     )
   }
 
   "Simple match" should "capture and add to the environment." in {
     val splitRand = rand.splitByte(0)
-    val result = withTestSpace {
-      case TestFixture(space, reducer) =>
-        val pattern =
-          Send(EVar(FreeVar(0)), List(GInt(7L), EVar(FreeVar(1))), persistent = false, BitSet())
-            .withConnectiveUsed(true)
-        val sendTarget =
-          Send(
-            EVar(BoundVar(1)),
-            List(GInt(7L), EVar(BoundVar(0))),
-            persistent = false,
-            BitSet(0, 1)
-          )
-        val matchTerm = Match(
-          sendTarget,
-          List(
-            MatchCase(
-              pattern,
-              Send(
-                GString("result"),
-                List(EVar(BoundVar(1)), EVar(BoundVar(0))),
-                false,
-                BitSet(0, 1)
-              ),
-              freeCount = 2
-            )
-          ),
-          BitSet()
+    val result    = withTestSpace { case TestFixture(space, reducer) =>
+      val pattern      =
+        Send(EVar(FreeVar(0)), List(GInt(7L), EVar(FreeVar(1))), persistent = false, BitSet())
+          .withConnectiveUsed(true)
+      val sendTarget   =
+        Send(
+          EVar(BoundVar(1)),
+          List(GInt(7L), EVar(BoundVar(0))),
+          persistent = false,
+          BitSet(0, 1),
         )
-        implicit val env = Env.makeEnv[Par](GPrivateBuilder("one"), GPrivateBuilder("zero"))
+      val matchTerm    = Match(
+        sendTarget,
+        List(
+          MatchCase(
+            pattern,
+            Send(
+              GString("result"),
+              List(EVar(BoundVar(1)), EVar(BoundVar(0))),
+              false,
+              BitSet(0, 1),
+            ),
+            freeCount = 2,
+          ),
+        ),
+        BitSet(),
+      )
+      implicit val env = Env.makeEnv[Par](GPrivateBuilder("one"), GPrivateBuilder("zero"))
 
-        val matchTask = reducer.eval(matchTerm)(env, splitRand)
-        val inspectTask = for {
-          _   <- matchTask
-          res <- space.toMap
-        } yield res
-        Await.result(inspectTask.unsafeToFuture(), 3.seconds)
+      val matchTask   = reducer.eval(matchTerm)(env, splitRand)
+      val inspectTask = for {
+        _   <- matchTask
+        res <- space.toMap
+      } yield res
+      Await.result(inspectTask.unsafeToFuture(), 3.seconds)
     }
 
-    val channel: Par = GString("result")
+    val channel: Par   = GString("result")
     val expectedResult = mapData(
       Map(
-        channel -> ((Seq(GPrivateBuilder("one"), GPrivateBuilder("zero")), splitRand))
-      )
+        channel -> ((Seq(GPrivateBuilder("one"), GPrivateBuilder("zero")), splitRand)),
+      ),
     )
     result.toSeq should contain theSameElementsAs expectedResult.toSeq
   }
 
   "eval of Send | Send | Receive join" should "meet in the tuplespace and proceed." in {
-    val splitRand0 = rand.splitByte(0)
-    val splitRand1 = rand.splitByte(1)
-    val splitRand2 = rand.splitByte(2)
-    val mergeRand  = Blake2b512Random.merge(Seq(splitRand2, splitRand0, splitRand1))
-    val send1 =
+    val splitRand0      = rand.splitByte(0)
+    val splitRand1      = rand.splitByte(1)
+    val splitRand2      = rand.splitByte(2)
+    val mergeRand       = Blake2b512Random.merge(Seq(splitRand2, splitRand0, splitRand1))
+    val send1           =
       Send(GString("channel1"), List(GInt(7L), GInt(8L), GInt(9L)), false, BitSet())
-    val send2 =
+    val send2           =
       Send(GString("channel2"), List(GInt(7L), GInt(8L), GInt(9L)), false, BitSet())
-    val receive = Receive(
+    val receive         = Receive(
       Seq(
         ReceiveBind(
           Seq(EVar(FreeVar(0)), EVar(FreeVar(1)), EVar(FreeVar(2))),
           GString("channel1"),
-          freeCount = 3
+          freeCount = 3,
         ),
         ReceiveBind(
           Seq(EVar(FreeVar(0)), EVar(FreeVar(1)), EVar(FreeVar(2))),
           GString("channel2"),
-          freeCount = 3
-        )
+          freeCount = 3,
+        ),
       ),
       Send(GString("result"), List(GString("Success")), false, BitSet()),
       false,
       false,
       3,
-      BitSet()
+      BitSet(),
     )
-    val sendFirstResult = withTestSpace {
-      case TestFixture(space, reducer) =>
-        val inspectTaskSendFirst = for {
-          _   <- reducer.inj(send1)(splitRand0)
-          _   <- reducer.inj(send2)(splitRand1)
-          _   <- reducer.inj(receive)(splitRand2)
-          res <- space.toMap
-        } yield res
-        Await.result(inspectTaskSendFirst.unsafeToFuture(), 3.seconds)
+    val sendFirstResult = withTestSpace { case TestFixture(space, reducer) =>
+      val inspectTaskSendFirst = for {
+        _   <- reducer.inj(send1)(splitRand0)
+        _   <- reducer.inj(send2)(splitRand1)
+        _   <- reducer.inj(receive)(splitRand2)
+        res <- space.toMap
+      } yield res
+      Await.result(inspectTaskSendFirst.unsafeToFuture(), 3.seconds)
     }
 
-    val channel: Par = GString("result")
+    val channel: Par   = GString("result")
     val expectedResult = mapData(
       Map(
-        channel -> ((Seq(GString("Success")), mergeRand))
-      )
+        channel -> ((Seq(GString("Success")), mergeRand)),
+      ),
     )
     sendFirstResult.toSeq should contain theSameElementsAs expectedResult.toSeq
 
-    val receiveFirstResult = withTestSpace {
-      case TestFixture(space, reducer) =>
-        implicit val env = Env[Par]()
-        val inspectTaskReceiveFirst = for {
-          _   <- reducer.eval(receive)(env, splitRand2)
-          _   <- reducer.eval(send1)(env, splitRand0)
-          _   <- reducer.eval(send2)(env, splitRand1)
-          res <- space.toMap
-        } yield res
-        Await.result(inspectTaskReceiveFirst.unsafeToFuture(), 3.seconds)
+    val receiveFirstResult = withTestSpace { case TestFixture(space, reducer) =>
+      implicit val env            = Env[Par]()
+      val inspectTaskReceiveFirst = for {
+        _   <- reducer.eval(receive)(env, splitRand2)
+        _   <- reducer.eval(send1)(env, splitRand0)
+        _   <- reducer.eval(send2)(env, splitRand1)
+        res <- space.toMap
+      } yield res
+      Await.result(inspectTaskReceiveFirst.unsafeToFuture(), 3.seconds)
     }
 
     receiveFirstResult.toSeq should contain theSameElementsAs expectedResult.toSeq
 
-    val interleavedResult = withTestSpace {
-      case TestFixture(space, reducer) =>
-        implicit val env = Env[Par]()
-        val inspectTaskInterleaved = for {
-          _   <- reducer.eval(send1)(env, splitRand0)
-          _   <- reducer.eval(receive)(env, splitRand2)
-          _   <- reducer.eval(send2)(env, splitRand1)
-          res <- space.toMap
-        } yield res
-        Await.result(inspectTaskInterleaved.unsafeToFuture(), 3.seconds)
+    val interleavedResult = withTestSpace { case TestFixture(space, reducer) =>
+      implicit val env           = Env[Par]()
+      val inspectTaskInterleaved = for {
+        _   <- reducer.eval(send1)(env, splitRand0)
+        _   <- reducer.eval(receive)(env, splitRand2)
+        _   <- reducer.eval(send2)(env, splitRand1)
+        res <- space.toMap
+      } yield res
+      Await.result(inspectTaskInterleaved.unsafeToFuture(), 3.seconds)
     }
 
     interleavedResult.toSeq should contain theSameElementsAs expectedResult.toSeq
@@ -757,42 +729,40 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
     val splitRand0 = rand.splitByte(0)
     val splitRand1 = rand.splitByte(1)
     val mergeRand  = Blake2b512Random.merge(Seq(splitRand1, splitRand0))
-    val send =
+    val send       =
       Send(GString("channel"), List(GInt(7L), GInt(8L), GInt(9L)), persistent = false, BitSet())
-    val receive =
+    val receive    =
       Receive(
         Seq(ReceiveBind(Seq(), GString("channel"), Some(FreeVar(0)), freeCount = 1)),
-        Send(GString("result"), Seq(EVar(BoundVar(0))))
+        Send(GString("result"), Seq(EVar(BoundVar(0)))),
       )
 
-    val result = withTestSpace {
-      case TestFixture(space, reducer) =>
-        implicit val env = Env[Par]()
-        val task = for {
-          _   <- reducer.eval(receive)(env, splitRand1)
-          _   <- reducer.eval(send)(env, splitRand0)
-          res <- space.toMap
-        } yield res
-        Await.result(task.unsafeToFuture(), 3.seconds)
+    val result = withTestSpace { case TestFixture(space, reducer) =>
+      implicit val env = Env[Par]()
+      val task         = for {
+        _   <- reducer.eval(receive)(env, splitRand1)
+        _   <- reducer.eval(send)(env, splitRand0)
+        res <- space.toMap
+      } yield res
+      Await.result(task.unsafeToFuture(), 3.seconds)
     }
 
-    val channel: Par = GString("result")
+    val channel: Par   = GString("result")
     val expectedResult = mapData(
       Map(
-        channel -> ((Seq(EList(List(GInt(7L), GInt(8L), GInt(9L)))), mergeRand))
-      )
+        channel -> ((Seq(EList(List(GInt(7L), GInt(8L), GInt(9L)))), mergeRand)),
+      ),
     )
     result.toSeq should contain theSameElementsAs expectedResult.toSeq
   }
 
   "eval of nth method" should "pick out the nth item from a list" in {
-    val splitRand = rand.splitByte(0)
-    val nthCall: Expr =
+    val splitRand           = rand.splitByte(0)
+    val nthCall: Expr       =
       EMethod("nth", EList(List(GInt(7L), GInt(8L), GInt(9L), GInt(10L))), List[Par](GInt(2L)))
-    val directResult: Par = withTestSpace {
-      case TestFixture(_, reducer) =>
-        implicit val env = Env[Par]()
-        Await.result(reducer.evalExprToPar(nthCall).unsafeToFuture(), 3.seconds)
+    val directResult: Par   = withTestSpace { case TestFixture(_, reducer) =>
+      implicit val env = Env[Par]()
+      Await.result(reducer.evalExprToPar(nthCall).unsafeToFuture(), 3.seconds)
     }
     val expectedResult: Par = GInt(9L)
     directResult should be(expectedResult)
@@ -805,61 +775,58 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
             GInt(7L),
             Send(GString("result"), List(GString("Success")), persistent = false, BitSet()),
             GInt(9L),
-            GInt(10L)
-          )
+            GInt(10L),
+          ),
         ),
-        List[Par](GInt(1L))
+        List[Par](GInt(1L)),
       )
-    val indirectResult = withTestSpace {
-      case TestFixture(space, reducer) =>
-        implicit val env = Env[Par]()
-        val nthTask      = reducer.eval(nthCallEvalToSend)(env, splitRand)
-        val inspectTask = for {
-          _   <- nthTask
-          res <- space.toMap
-        } yield res
-        Await.result(inspectTask.unsafeToFuture(), 3.seconds)
+    val indirectResult          = withTestSpace { case TestFixture(space, reducer) =>
+      implicit val env = Env[Par]()
+      val nthTask      = reducer.eval(nthCallEvalToSend)(env, splitRand)
+      val inspectTask  = for {
+        _   <- nthTask
+        res <- space.toMap
+      } yield res
+      Await.result(inspectTask.unsafeToFuture(), 3.seconds)
     }
 
-    val channel: Par = GString("result")
+    val channel: Par           = GString("result")
     val expectedIndirectResult = mapData(
       Map(
-        channel -> ((Seq(GString("Success")), splitRand))
-      )
+        channel -> ((Seq(GString("Success")), splitRand)),
+      ),
     )
     indirectResult.toSeq should contain theSameElementsAs expectedIndirectResult.toSeq
   }
 
   "eval of nth method" should "pick out the nth item from a ByteArray" in {
-    val nthCall: Expr =
+    val nthCall: Expr       =
       EMethod("nth", GByteArray(ByteString.copyFrom(Array[Byte](1, 2, -1))), List[Par](GInt(2L)))
-    val directResult: Par = withTestSpace {
-      case TestFixture(_, reducer) =>
-        implicit val env = Env[Par]()
-        Await.result(reducer.evalExprToPar(nthCall).unsafeToFuture(), 3.seconds)
+    val directResult: Par   = withTestSpace { case TestFixture(_, reducer) =>
+      implicit val env = Env[Par]()
+      Await.result(reducer.evalExprToPar(nthCall).unsafeToFuture(), 3.seconds)
     }
     val expectedResult: Par = GInt(255.toLong)
     directResult should be(expectedResult)
   }
 
   "eval of length method" should "get length of ByteArray" in {
-    val nthCall: Expr =
+    val nthCall: Expr       =
       EMethod("length", GByteArray(ByteString.copyFrom(Array[Byte](1, 2, -1))), List[Par]())
-    val directResult: Par = withTestSpace {
-      case TestFixture(_, reducer) =>
-        implicit val env = Env[Par]()
-        Await.result(reducer.evalExprToPar(nthCall).unsafeToFuture(), 3.seconds)
+    val directResult: Par   = withTestSpace { case TestFixture(_, reducer) =>
+      implicit val env = Env[Par]()
+      Await.result(reducer.evalExprToPar(nthCall).unsafeToFuture(), 3.seconds)
     }
     val expectedResult: Par = GInt(3.toLong)
     directResult should be(expectedResult)
   }
 
   "eval of New" should "use deterministic names and provide urn-based resources" in {
-    val splitRand   = rand.splitByte(42)
-    val resultRand  = rand.splitByte(42)
-    val chosenName  = resultRand.next()
-    val result0Rand = resultRand.splitByte(0)
-    val result1Rand = resultRand.splitByte(1)
+    val splitRand    = rand.splitByte(42)
+    val resultRand   = rand.splitByte(42)
+    val chosenName   = resultRand.next()
+    val result0Rand  = resultRand.splitByte(0)
+    val result1Rand  = resultRand.splitByte(1)
     val newProc: New =
       New(
         bindCount = 2,
@@ -867,25 +834,24 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
         p = Par(
           sends = List(
             Send(GString("result0"), List(EVar(BoundVar(0))), locallyFree = BitSet(0)),
-            Send(GString("result1"), List(EVar(BoundVar(1))), locallyFree = BitSet(1))
+            Send(GString("result1"), List(EVar(BoundVar(1))), locallyFree = BitSet(1)),
           ),
-          locallyFree = BitSet(0, 1)
-        )
+          locallyFree = BitSet(0, 1),
+        ),
       )
 
-    val result = withTestSpace {
-      case TestFixture(space, _) =>
-        implicit val cost          = CostAccounting.emptyCost[IO].unsafeRunSync()
-        def byteName(b: Byte): Par = GPrivate(ByteString.copyFrom(Array[Byte](b)))
-        val reducer                = RholangOnlyDispatcher(space, Map("rho:test:foo" -> byteName(42)))._2
-        cost.set(Cost.UNSAFE_MAX).unsafeRunSync()
-        implicit val env = Env[Par]()
-        val nthTask      = reducer.eval(newProc)(env, splitRand)
-        val inspectTask = for {
-          _   <- nthTask
-          res <- space.toMap
-        } yield res
-        Await.result(inspectTask.unsafeToFuture(), 3.seconds)
+    val result = withTestSpace { case TestFixture(space, _) =>
+      implicit val cost          = CostAccounting.emptyCost[IO].unsafeRunSync()
+      def byteName(b: Byte): Par = GPrivate(ByteString.copyFrom(Array[Byte](b)))
+      val reducer                = RholangOnlyDispatcher(space, Map("rho:test:foo" -> byteName(42)))._2
+      cost.set(Cost.UNSAFE_MAX).unsafeRunSync()
+      implicit val env           = Env[Par]()
+      val nthTask                = reducer.eval(newProc)(env, splitRand)
+      val inspectTask            = for {
+        _   <- nthTask
+        res <- space.toMap
+      } yield res
+      Await.result(inspectTask.unsafeToFuture(), 3.seconds)
     }
 
     val channel0: Par = GString("result0")
@@ -914,7 +880,7 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
   }
   // format: on
   "eval of nth method in send position" should "change what is sent" in {
-    val splitRand = rand.splitByte(0)
+    val splitRand               = rand.splitByte(0)
     val nthCallEvalToSend: Expr =
       EMethod(
         "nth",
@@ -923,22 +889,21 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
             GInt(7L),
             Send(GString("result"), List(GString("Success")), persistent = false, BitSet()),
             GInt(9L),
-            GInt(10L)
-          )
+            GInt(10L),
+          ),
         ),
-        List[Par](GInt(1L))
+        List[Par](GInt(1L)),
       )
-    val send: Par =
+    val send: Par               =
       Send(GString("result"), List[Par](nthCallEvalToSend), persistent = false, BitSet())
-    val result = withTestSpace {
-      case TestFixture(space, reducer) =>
-        implicit val env = Env[Par]()
-        val nthTask      = reducer.eval(send)(env, splitRand)
-        val inspectTask = for {
-          _   <- nthTask
-          res <- space.toMap
-        } yield res
-        Await.result(inspectTask.unsafeToFuture(), 3.seconds)
+    val result                  = withTestSpace { case TestFixture(space, reducer) =>
+      implicit val env = Env[Par]()
+      val nthTask      = reducer.eval(send)(env, splitRand)
+      val inspectTask  = for {
+        _   <- nthTask
+        res <- space.toMap
+      } yield res
+      Await.result(inspectTask.unsafeToFuture(), 3.seconds)
     }
 
     val channel: Par = GString("result")
@@ -948,10 +913,10 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
         channel -> (
           (
             Seq(Send(GString("result"), List(GString("Success")), persistent = false, BitSet())),
-            splitRand
+            splitRand,
           )
-        )
-      )
+        ),
+      ),
     )
     result.toSeq should contain theSameElementsAs expectedResult.toSeq
   }
@@ -959,70 +924,67 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
   "eval of a method" should "substitute target before evaluating" in {
     val hexToBytesCall: Expr =
       EMethod("hexToBytes", Expr(EVarBody(EVar(Var(BoundVar(0))))))
-    val directResult: Par = withTestSpace {
-      case TestFixture(_, reducer) =>
-        implicit val env = Env.makeEnv[Par](Expr(GString("deadbeef")))
-        Await.result(reducer.evalExprToPar(hexToBytesCall).unsafeToFuture(), 3.seconds)
+    val directResult: Par    = withTestSpace { case TestFixture(_, reducer) =>
+      implicit val env = Env.makeEnv[Par](Expr(GString("deadbeef")))
+      Await.result(reducer.evalExprToPar(hexToBytesCall).unsafeToFuture(), 3.seconds)
     }
-    val expectedResult: Par = Expr(GByteArray("deadbeef".unsafeHexToByteString))
+    val expectedResult: Par  = Expr(GByteArray("deadbeef".unsafeHexToByteString))
     directResult should be(expectedResult)
   }
 
   "eval of `toByteArray` method on any process" should "return that process serialized" in {
-    val splitRand = rand.splitByte(0)
-    val proc = Receive(
+    val splitRand                 = rand.splitByte(0)
+    val proc                      = Receive(
       Seq(ReceiveBind(Seq(EVar(FreeVar(0))), GString("channel"))),
       Par(),
       persistent = false,
       peek = false,
       1,
-      BitSet()
+      BitSet(),
     )
-    val serializedProcess =
+    val serializedProcess         =
       com.google.protobuf.ByteString.copyFrom(Serialize[Par].encode(proc).toArray)
-    val toByteArrayCall = EMethod("toByteArray", proc, List[Par]())
+    val toByteArrayCall           = EMethod("toByteArray", proc, List[Par]())
     def wrapWithSend(p: Par): Par =
       Send(GString("result"), List[Par](p), persistent = false, BitSet())
-    val result = withTestSpace {
-      case TestFixture(space, reducer) =>
-        val env         = Env[Par]()
-        val task        = reducer.eval(wrapWithSend(toByteArrayCall))(env, splitRand)
-        val inspectTask = task >> space.toMap
-        Await.result(inspectTask.unsafeToFuture(), 3.seconds)
+    val result                    = withTestSpace { case TestFixture(space, reducer) =>
+      val env         = Env[Par]()
+      val task        = reducer.eval(wrapWithSend(toByteArrayCall))(env, splitRand)
+      val inspectTask = task >> space.toMap
+      Await.result(inspectTask.unsafeToFuture(), 3.seconds)
     }
 
-    val channel: Par = GString("result")
+    val channel: Par   = GString("result")
     val expectedResult = mapData(
       Map(
-        channel -> ((Seq(Expr(GByteArray(serializedProcess))), splitRand))
-      )
+        channel -> ((Seq(Expr(GByteArray(serializedProcess))), splitRand)),
+      ),
     )
     result.toSeq should contain theSameElementsAs expectedResult.toSeq
   }
 
   it should "substitute before serialization" in {
-    val splitRand = rand.splitByte(0)
-    val unsubProc: Par =
+    val splitRand                 = rand.splitByte(0)
+    val unsubProc: Par            =
       New(bindCount = 1, p = EVar(BoundVar(1)), locallyFree = BitSet(0))
-    val subProc: Par =
+    val subProc: Par              =
       New(bindCount = 1, p = GPrivateBuilder("zero"), locallyFree = BitSet())
     val serializedProcess         = subProc.toByteString
     val toByteArrayCall: Par      = EMethod("toByteArray", unsubProc, List[Par](), BitSet(0))
     val channel: Par              = GString("result")
     def wrapWithSend(p: Par): Par = Send(channel, List[Par](p), persistent = false, p.locallyFree)
 
-    val result = withTestSpace {
-      case TestFixture(space, reducer) =>
-        val env         = Env.makeEnv[Par](GPrivateBuilder("one"), GPrivateBuilder("zero"))
-        val task        = reducer.eval(wrapWithSend(toByteArrayCall))(env, splitRand)
-        val inspectTask = task >> space.toMap
-        Await.result(inspectTask.unsafeToFuture(), 3.seconds)
+    val result = withTestSpace { case TestFixture(space, reducer) =>
+      val env         = Env.makeEnv[Par](GPrivateBuilder("one"), GPrivateBuilder("zero"))
+      val task        = reducer.eval(wrapWithSend(toByteArrayCall))(env, splitRand)
+      val inspectTask = task >> space.toMap
+      Await.result(inspectTask.unsafeToFuture(), 3.seconds)
     }
 
     val expectedResult = mapData(
       Map(
-        channel -> ((Seq(Expr(GByteArray(serializedProcess))), splitRand))
-      )
+        channel -> ((Seq(Expr(GByteArray(serializedProcess))), splitRand)),
+      ),
     )
     result.toSeq should contain theSameElementsAs expectedResult.toSeq
   }
@@ -1032,92 +994,87 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
       EMethod(
         "toByteArray",
         Par(
-          sends =
-            Seq(Send(GString("result"), List(GString("Success")), persistent = false, BitSet()))
+          sends = Seq(Send(GString("result"), List(GString("Success")), persistent = false, BitSet())),
         ),
-        List[Par](GInt(1L))
+        List[Par](GInt(1L)),
       )
 
-    val result = withTestSpace {
-      case TestFixture(space, reducer) =>
-        implicit val env = Env[Par]()
-        val nthTask      = reducer.eval(toByteArrayWithArgumentsCall)
-        val inspectTask  = nthTask >> space.toMap
-        Await.ready(inspectTask.unsafeToFuture(), 3.seconds)
+    val result = withTestSpace { case TestFixture(space, reducer) =>
+      implicit val env = Env[Par]()
+      val nthTask      = reducer.eval(toByteArrayWithArgumentsCall)
+      val inspectTask  = nthTask >> space.toMap
+      Await.ready(inspectTask.unsafeToFuture(), 3.seconds)
     }
     result.value shouldBe Failure(MethodArgumentNumberMismatch("toByteArray", 0, 1)).some
   }
 
   "eval of hexToBytes" should "transform encoded string to byte array (not the rholang term)" in {
-    val splitRand       = rand.splitByte(0)
-    val testString      = "testing testing"
-    val base16Repr      = Base16.encode(testString.getBytes)
-    val proc: Par       = GString(base16Repr)
-    val toByteArrayCall = EMethod("hexToBytes", proc, List[Par]())
+    val splitRand                 = rand.splitByte(0)
+    val testString                = "testing testing"
+    val base16Repr                = Base16.encode(testString.getBytes)
+    val proc: Par                 = GString(base16Repr)
+    val toByteArrayCall           = EMethod("hexToBytes", proc, List[Par]())
     def wrapWithSend(p: Par): Par =
       Send(GString("result"), List[Par](p), persistent = false, BitSet())
-    val result = withTestSpace {
-      case TestFixture(space, reducer) =>
-        val env         = Env[Par]()
-        val task        = reducer.eval(wrapWithSend(toByteArrayCall))(env, splitRand)
-        val inspectTask = task >> space.toMap
-        Await.result(inspectTask.unsafeToFuture(), 3.seconds)
+    val result                    = withTestSpace { case TestFixture(space, reducer) =>
+      val env         = Env[Par]()
+      val task        = reducer.eval(wrapWithSend(toByteArrayCall))(env, splitRand)
+      val inspectTask = task >> space.toMap
+      Await.result(inspectTask.unsafeToFuture(), 3.seconds)
     }
 
-    val channel: Par = GString("result")
+    val channel: Par   = GString("result")
     val expectedResult = mapData(
       Map(
-        channel -> ((Seq(Expr(GByteArray(ByteString.copyFrom(testString.getBytes)))), splitRand))
-      )
+        channel -> ((Seq(Expr(GByteArray(ByteString.copyFrom(testString.getBytes)))), splitRand)),
+      ),
     )
     result.toSeq should contain theSameElementsAs expectedResult.toSeq
   }
 
   "eval of bytesToHex" should "transform byte array to hex string (not the rholang term)" in {
-    val splitRand    = rand.splitByte(0)
-    val base16Repr   = "0123456789abcdef"
-    val testBytes    = base16Repr.unsafeHexToByteString
-    val proc: Par    = GByteArray(testBytes)
-    val toStringCall = EMethod("bytesToHex", proc, List[Par]())
+    val splitRand                 = rand.splitByte(0)
+    val base16Repr                = "0123456789abcdef"
+    val testBytes                 = base16Repr.unsafeHexToByteString
+    val proc: Par                 = GByteArray(testBytes)
+    val toStringCall              = EMethod("bytesToHex", proc, List[Par]())
     def wrapWithSend(p: Par): Par =
       Send(GString("result"), List[Par](p), persistent = false, BitSet())
-    val result = withTestSpace {
-      case TestFixture(space, reducer) =>
-        val env         = Env[Par]()
-        val task        = reducer.eval(wrapWithSend(toStringCall))(env, splitRand)
-        val inspectTask = task >> space.toMap
-        Await.result(inspectTask.unsafeToFuture(), 3.seconds)
+    val result                    = withTestSpace { case TestFixture(space, reducer) =>
+      val env         = Env[Par]()
+      val task        = reducer.eval(wrapWithSend(toStringCall))(env, splitRand)
+      val inspectTask = task >> space.toMap
+      Await.result(inspectTask.unsafeToFuture(), 3.seconds)
     }
 
-    val channel: Par = GString("result")
+    val channel: Par   = GString("result")
     val expectedResult = mapData(
       Map(
-        channel -> ((Seq(Expr(GString(base16Repr))), splitRand))
-      )
+        channel -> ((Seq(Expr(GString(base16Repr))), splitRand)),
+      ),
     )
     result.toSeq should contain theSameElementsAs expectedResult.toSeq
   }
 
   "eval of `toUtf8Bytes`" should "transform string to UTF-8 byte array (not the rholang term)" in {
-    val splitRand       = rand.splitByte(0)
-    val testString      = "testing testing"
-    val proc: Par       = GString(testString)
-    val toUtf8BytesCall = EMethod("toUtf8Bytes", proc, List[Par]())
+    val splitRand                 = rand.splitByte(0)
+    val testString                = "testing testing"
+    val proc: Par                 = GString(testString)
+    val toUtf8BytesCall           = EMethod("toUtf8Bytes", proc, List[Par]())
     def wrapWithSend(p: Par): Par =
       Send(GString("result"), List[Par](p), persistent = false, BitSet())
-    val result = withTestSpace {
-      case TestFixture(space, reducer) =>
-        val env         = Env[Par]()
-        val task        = reducer.eval(wrapWithSend(toUtf8BytesCall))(env, splitRand)
-        val inspectTask = task >> space.toMap
-        Await.result(inspectTask.unsafeToFuture(), 3.seconds)
+    val result                    = withTestSpace { case TestFixture(space, reducer) =>
+      val env         = Env[Par]()
+      val task        = reducer.eval(wrapWithSend(toUtf8BytesCall))(env, splitRand)
+      val inspectTask = task >> space.toMap
+      Await.result(inspectTask.unsafeToFuture(), 3.seconds)
     }
 
-    val channel: Par = GString("result")
+    val channel: Par   = GString("result")
     val expectedResult = mapData(
       Map(
-        channel -> ((Seq(Expr(GByteArray(ByteString.copyFrom(testString.getBytes)))), splitRand))
-      )
+        channel -> ((Seq(Expr(GByteArray(ByteString.copyFrom(testString.getBytes)))), splitRand)),
+      ),
     )
     result.toSeq should contain theSameElementsAs expectedResult.toSeq
   }
@@ -1127,18 +1084,16 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
       EMethod(
         "toUtf8Bytes",
         Par(
-          sends =
-            Seq(Send(GString("result"), List(GString("Success")), persistent = false, BitSet()))
+          sends = Seq(Send(GString("result"), List(GString("Success")), persistent = false, BitSet())),
         ),
-        List[Par](GInt(1L))
+        List[Par](GInt(1L)),
       )
 
-    val result = withTestSpace {
-      case TestFixture(space, reducer) =>
-        implicit val env = Env[Par]()
-        val nthTask      = reducer.eval(toUtfBytesWithArgumentsCall)
-        val inspectTask  = nthTask >> space.toMap
-        Await.ready(inspectTask.unsafeToFuture(), 3.seconds)
+    val result = withTestSpace { case TestFixture(space, reducer) =>
+      implicit val env = Env[Par]()
+      val nthTask      = reducer.eval(toUtfBytesWithArgumentsCall)
+      val inspectTask  = nthTask >> space.toMap
+      Await.ready(inspectTask.unsafeToFuture(), 3.seconds)
     }
     result.value shouldBe Failure(MethodArgumentNumberMismatch("toUtf8Bytes", 0, 1)).some
   }
@@ -1146,12 +1101,11 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
   it should "return an error when `toUtf8Bytes` is evaluated on a non String" in {
     val toUtfBytesCall = EMethod("toUtf8Bytes", GInt(44L), List[Par]())
 
-    val result = withTestSpace {
-      case TestFixture(space, reducer) =>
-        implicit val env = Env[Par]()
-        val nthTask      = reducer.eval(toUtfBytesCall)
-        val inspectTask  = nthTask >> space.toMap
-        Await.ready(inspectTask.unsafeToFuture(), 3.seconds)
+    val result = withTestSpace { case TestFixture(space, reducer) =>
+      implicit val env = Env[Par]()
+      val nthTask      = reducer.eval(toUtfBytesCall)
+      val inspectTask  = nthTask >> space.toMap
+      Await.ready(inspectTask.unsafeToFuture(), 3.seconds)
     }
     result.value shouldBe Failure(MethodNotDefined("toUtf8Bytes", "Int")).some
   }
@@ -1160,17 +1114,17 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
     val splitRandResult = rand.splitByte(3)
     val splitRandSrc    = rand.splitByte(3)
     splitRandResult.next()
-    val mergeRand =
+    val mergeRand       =
       Blake2b512Random.merge(Seq(splitRandResult.splitByte(1), splitRandResult.splitByte(0)))
-    val proc = New(
+    val proc            = New(
       bindCount = 1,
       p = Par(
         sends = List(
           Send(
             chan = EVar(BoundVar(0)),
             data = List(EVar(BoundVar(0))),
-            persistent = false
-          )
+            persistent = false,
+          ),
         ),
         receives = List(
           Receive(
@@ -1178,29 +1132,28 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
               ReceiveBind(
                 patterns = List(Connective(VarRefBody(VarRef(0, 1)))),
                 source = EVar(BoundVar(0)),
-                freeCount = 0
-              )
+                freeCount = 0,
+              ),
             ),
             body = Send(chan = GString("result"), data = List(GString("true"))),
-            bindCount = 0
-          )
-        )
-      )
+            bindCount = 0,
+          ),
+        ),
+      ),
     )
 
-    val result = withTestSpace {
-      case TestFixture(space, reducer) =>
-        val env         = Env[Par]()
-        val task        = reducer.eval(proc)(env, splitRandSrc)
-        val inspectTask = task >> space.toMap
-        Await.result(inspectTask.unsafeToFuture(), 3.seconds)
+    val result = withTestSpace { case TestFixture(space, reducer) =>
+      val env         = Env[Par]()
+      val task        = reducer.eval(proc)(env, splitRandSrc)
+      val inspectTask = task >> space.toMap
+      Await.result(inspectTask.unsafeToFuture(), 3.seconds)
     }
 
-    val channel: Par = GString("result")
+    val channel: Par   = GString("result")
     val expectedResult = mapData(
       Map(
-        channel -> ((Seq(GString("true")), mergeRand))
-      )
+        channel -> ((Seq(GString("true")), mergeRand)),
+      ),
     )
     result.toSeq should contain theSameElementsAs expectedResult.toSeq
   }
@@ -1209,31 +1162,30 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
     val splitRandResult = rand.splitByte(4)
     val splitRandSrc    = rand.splitByte(4)
     splitRandResult.next()
-    val proc = New(
+    val proc            = New(
       bindCount = 1,
       p = Match(
         target = EVar(BoundVar(0)),
         cases = List(
           MatchCase(
             pattern = Connective(VarRefBody(VarRef(0, 1))),
-            source = Send(chan = GString("result"), data = List(GString("true")))
-          )
-        )
-      )
+            source = Send(chan = GString("result"), data = List(GString("true"))),
+          ),
+        ),
+      ),
     )
 
-    val result = withTestSpace {
-      case TestFixture(space, reducer) =>
-        val env         = Env[Par]()
-        val task        = reducer.eval(proc)(env, splitRandSrc)
-        val inspectTask = task >> space.toMap
-        Await.result(inspectTask.unsafeToFuture(), 3.seconds)
+    val result         = withTestSpace { case TestFixture(space, reducer) =>
+      val env         = Env[Par]()
+      val task        = reducer.eval(proc)(env, splitRandSrc)
+      val inspectTask = task >> space.toMap
+      Await.result(inspectTask.unsafeToFuture(), 3.seconds)
     }
-    val channel: Par = GString("result")
+    val channel: Par   = GString("result")
     val expectedResult = mapData(
       Map(
-        channel -> ((Seq(GString("true")), splitRandResult))
-      )
+        channel -> ((Seq(GString("true")), splitRandResult)),
+      ),
     )
     result.toSeq should contain theSameElementsAs expectedResult.toSeq
   }
@@ -1243,7 +1195,7 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
     val splitRand0 = baseRand.splitByte(0)
     val splitRand1 = baseRand.splitByte(1)
     val mergeRand  = Blake2b512Random.merge(Seq(splitRand1, splitRand0))
-    val proc = Par(
+    val proc       = Par(
       sends = List(Send(chan = GInt(7L), data = List(GInt(10L)))),
       receives = List(
         Receive(
@@ -1251,204 +1203,190 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
             ReceiveBind(
               patterns = List(EVar(FreeVar(0))),
               source = GInt(7L),
-              freeCount = 1
-            )
+              freeCount = 1,
+            ),
           ),
           body = Match(
             GInt(10L),
             List(
               MatchCase(
                 pattern = Connective(VarRefBody(VarRef(0, 1))),
-                source = Send(chan = GString("result"), data = List(GString("true")))
-              )
-            )
-          )
-        )
-      )
+                source = Send(chan = GString("result"), data = List(GString("true"))),
+              ),
+            ),
+          ),
+        ),
+      ),
     )
 
-    val result = withTestSpace {
-      case TestFixture(space, reducer) =>
-        val env         = Env[Par]()
-        val task        = reducer.eval(proc)(env, baseRand)
-        val inspectTask = task >> space.toMap
-        Await.result(inspectTask.unsafeToFuture(), 3.seconds)
+    val result = withTestSpace { case TestFixture(space, reducer) =>
+      val env         = Env[Par]()
+      val task        = reducer.eval(proc)(env, baseRand)
+      val inspectTask = task >> space.toMap
+      Await.result(inspectTask.unsafeToFuture(), 3.seconds)
     }
 
-    val channel: Par = GString("result")
+    val channel: Par   = GString("result")
     val expectedResult = mapData(
       Map(
-        channel -> ((Seq(GString("true")), mergeRand))
-      )
+        channel -> ((Seq(GString("true")), mergeRand)),
+      ),
     )
     result.toSeq should contain theSameElementsAs expectedResult.toSeq
   }
 
   "1 matches 1" should "return true" in {
-    val result = withTestSpace {
-      case TestFixture(_, reducer) =>
-        implicit val env = Env.makeEnv[Par]()
-        val inspectTask  = reducer.evalExpr(EMatches(GInt(1L), GInt(1L)))
-        Await.result(inspectTask.unsafeToFuture(), 3.seconds)
+    val result = withTestSpace { case TestFixture(_, reducer) =>
+      implicit val env = Env.makeEnv[Par]()
+      val inspectTask  = reducer.evalExpr(EMatches(GInt(1L), GInt(1L)))
+      Await.result(inspectTask.unsafeToFuture(), 3.seconds)
     }
 
     result.exprs should be(Seq(Expr(GBool(true))))
   }
 
   "1 matches 0" should "return false" in {
-    val result = withTestSpace {
-      case TestFixture(_, reducer) =>
-        implicit val env = Env.makeEnv[Par]()
-        val inspectTask  = reducer.evalExpr(EMatches(GInt(1L), GInt(0L)))
-        Await.result(inspectTask.unsafeToFuture(), 3.seconds)
+    val result = withTestSpace { case TestFixture(_, reducer) =>
+      implicit val env = Env.makeEnv[Par]()
+      val inspectTask  = reducer.evalExpr(EMatches(GInt(1L), GInt(0L)))
+      Await.result(inspectTask.unsafeToFuture(), 3.seconds)
     }
 
     result.exprs should be(Seq(Expr(GBool(false))))
   }
 
   "1 matches _" should "return true" in {
-    val result = withTestSpace {
-      case TestFixture(_, reducer) =>
-        implicit val env = Env.makeEnv[Par]()
-        val inspectTask  = reducer.evalExpr(EMatches(GInt(1L), EVar(Wildcard(Var.WildcardMsg()))))
-        Await.result(inspectTask.unsafeToFuture(), 3.seconds)
+    val result = withTestSpace { case TestFixture(_, reducer) =>
+      implicit val env = Env.makeEnv[Par]()
+      val inspectTask  = reducer.evalExpr(EMatches(GInt(1L), EVar(Wildcard(Var.WildcardMsg()))))
+      Await.result(inspectTask.unsafeToFuture(), 3.seconds)
     }
 
     result.exprs should be(Seq(Expr(GBool(true))))
   }
 
   "x matches 1" should "return true when x is bound to 1" in {
-    val result = withTestSpace {
-      case TestFixture(_, reducer) =>
-        implicit val env = Env.makeEnv[Par](GInt(1L))
-        val inspectTask  = reducer.evalExpr(EMatches(EVar(BoundVar(0)), GInt(1L)))
-        Await.result(inspectTask.unsafeToFuture(), 3.seconds)
+    val result = withTestSpace { case TestFixture(_, reducer) =>
+      implicit val env = Env.makeEnv[Par](GInt(1L))
+      val inspectTask  = reducer.evalExpr(EMatches(EVar(BoundVar(0)), GInt(1L)))
+      Await.result(inspectTask.unsafeToFuture(), 3.seconds)
     }
 
     result.exprs should be(Seq(Expr(GBool(true))))
   }
 
   "1 matches =x" should "return true when x is bound to 1" in {
-    val result = withTestSpace {
-      case TestFixture(_, reducer) =>
-        implicit val env = Env.makeEnv[Par](GInt(1L))
+    val result = withTestSpace { case TestFixture(_, reducer) =>
+      implicit val env = Env.makeEnv[Par](GInt(1L))
 
-        val inspectTask = reducer.evalExpr(EMatches(GInt(1L), Connective(VarRefBody(VarRef(0, 1)))))
+      val inspectTask = reducer.evalExpr(EMatches(GInt(1L), Connective(VarRefBody(VarRef(0, 1)))))
 
-        Await.result(inspectTask.unsafeToFuture(), 3.seconds)
+      Await.result(inspectTask.unsafeToFuture(), 3.seconds)
     }
 
     result.exprs should be(Seq(Expr(GBool(true))))
   }
 
   "'abc'.length()" should "return the length of the string" in {
-    val result = withTestSpace {
-      case TestFixture(_, reducer) =>
-        implicit val env = Env.makeEnv[Par]()
-        val inspectTask  = reducer.evalExpr(EMethodBody(EMethod("length", GString("abc"))))
-        Await.result(inspectTask.unsafeToFuture(), 3.seconds)
+    val result = withTestSpace { case TestFixture(_, reducer) =>
+      implicit val env = Env.makeEnv[Par]()
+      val inspectTask  = reducer.evalExpr(EMethodBody(EMethod("length", GString("abc"))))
+      Await.result(inspectTask.unsafeToFuture(), 3.seconds)
     }
     result.exprs should be(Seq(Expr(GInt(3L))))
   }
 
   "'abcabac'.slice(3, 6)" should "return 'aba'" in {
-    val result = withTestSpace {
-      case TestFixture(_, reducer) =>
-        implicit val env = Env.makeEnv[Par]()
-        val inspectTask = reducer.evalExpr(
-          EMethodBody(EMethod("slice", GString("abcabac"), List(GInt(3L), GInt(6L))))
-        )
-        Await.result(inspectTask.unsafeToFuture(), 3.seconds)
+    val result = withTestSpace { case TestFixture(_, reducer) =>
+      implicit val env = Env.makeEnv[Par]()
+      val inspectTask  = reducer.evalExpr(
+        EMethodBody(EMethod("slice", GString("abcabac"), List(GInt(3L), GInt(6L)))),
+      )
+      Await.result(inspectTask.unsafeToFuture(), 3.seconds)
     }
     result.exprs should be(Seq(Expr(GString("aba"))))
   }
 
   "'abcabcac'.slice(2,1)" should "return empty string" in {
-    val result = withTestSpace {
-      case TestFixture(_, reducer) =>
-        implicit val env = Env.makeEnv[Par]()
-        val inspectTask = reducer.evalExpr(
-          EMethodBody(EMethod("slice", GString("abcabac"), List(GInt(2L), GInt(1L))))
-        )
-        Await.result(inspectTask.unsafeToFuture(), 3.seconds)
+    val result = withTestSpace { case TestFixture(_, reducer) =>
+      implicit val env = Env.makeEnv[Par]()
+      val inspectTask  = reducer.evalExpr(
+        EMethodBody(EMethod("slice", GString("abcabac"), List(GInt(2L), GInt(1L)))),
+      )
+      Await.result(inspectTask.unsafeToFuture(), 3.seconds)
     }
     result.exprs should be(Seq(Expr(GString(""))))
   }
 
   "'abcabcac'.slice(8,9)" should "return empty string" in {
-    val result = withTestSpace {
-      case TestFixture(_, reducer) =>
-        implicit val env = Env.makeEnv[Par]()
-        val inspectTask = reducer.evalExpr(
-          EMethodBody(EMethod("slice", GString("abcabac"), List(GInt(8L), GInt(9L))))
-        )
-        Await.result(inspectTask.unsafeToFuture(), 3.seconds)
+    val result = withTestSpace { case TestFixture(_, reducer) =>
+      implicit val env = Env.makeEnv[Par]()
+      val inspectTask  = reducer.evalExpr(
+        EMethodBody(EMethod("slice", GString("abcabac"), List(GInt(8L), GInt(9L)))),
+      )
+      Await.result(inspectTask.unsafeToFuture(), 3.seconds)
     }
     result.exprs should be(Seq(Expr(GString(""))))
   }
 
   "'abcabcac'.slice(-2,2)" should "return 'ab'" in {
-    val result = withTestSpace {
-      case TestFixture(_, reducer) =>
-        implicit val env = Env.makeEnv[Par]()
-        val inspectTask = reducer.evalExpr(
-          EMethodBody(EMethod("slice", GString("abcabac"), List(GInt(-2L), GInt(2L))))
-        )
-        Await.result(inspectTask.unsafeToFuture(), 3.seconds)
+    val result = withTestSpace { case TestFixture(_, reducer) =>
+      implicit val env = Env.makeEnv[Par]()
+      val inspectTask  = reducer.evalExpr(
+        EMethodBody(EMethod("slice", GString("abcabac"), List(GInt(-2L), GInt(2L)))),
+      )
+      Await.result(inspectTask.unsafeToFuture(), 3.seconds)
     }
     result.exprs should be(Seq(Expr(GString("ab"))))
   }
 
   "'Hello, ${name}!' % {'name': 'Alice'}" should "return 'Hello, Alice!" in {
-    val result = withTestSpace {
-      case TestFixture(_, reducer) =>
-        implicit val env = Env.makeEnv[Par]()
-        val inspectTask = reducer.evalExpr(
-          EPercentPercentBody(
-            EPercentPercent(
-              GString("Hello, ${name}!"),
-              EMapBody(ParMap(List[(Par, Par)]((GString("name"), GString("Alice")))))
-            )
-          )
-        )
-        Await.result(inspectTask.unsafeToFuture(), 3.seconds)
+    val result = withTestSpace { case TestFixture(_, reducer) =>
+      implicit val env = Env.makeEnv[Par]()
+      val inspectTask  = reducer.evalExpr(
+        EPercentPercentBody(
+          EPercentPercent(
+            GString("Hello, ${name}!"),
+            EMapBody(ParMap(List[(Par, Par)]((GString("name"), GString("Alice"))))),
+          ),
+        ),
+      )
+      Await.result(inspectTask.unsafeToFuture(), 3.seconds)
     }
     result.exprs should be(Seq(Expr(GString("Hello, Alice!"))))
   }
 
   "'abc' ++ 'def'" should "return 'abcdef" in {
-    val result = withTestSpace {
-      case TestFixture(_, reducer) =>
-        implicit val env = Env.makeEnv[Par]()
-        val inspectTask = reducer.evalExpr(
-          EPlusPlusBody(
-            EPlusPlus(
-              GString("abc"),
-              GString("def")
-            )
-          )
-        )
-        Await.result(inspectTask.unsafeToFuture(), 3.seconds)
+    val result = withTestSpace { case TestFixture(_, reducer) =>
+      implicit val env = Env.makeEnv[Par]()
+      val inspectTask  = reducer.evalExpr(
+        EPlusPlusBody(
+          EPlusPlus(
+            GString("abc"),
+            GString("def"),
+          ),
+        ),
+      )
+      Await.result(inspectTask.unsafeToFuture(), 3.seconds)
     }
     result.exprs should be(Seq(Expr(GString("abcdef"))))
   }
 
   "ByteArray('dead') ++ ByteArray('beef)'" should "return ByteArray('deadbeef')" in {
-    val result = withTestSpace {
-      case TestFixture(_, reducer) =>
-        implicit val env = Env.makeEnv[Par]()
-        val inspectTask = reducer.evalExpr(
-          EPlusPlusBody(
-            EPlusPlus(
-              GByteArray("dead".unsafeHexToByteString),
-              GByteArray("beef".unsafeHexToByteString)
-            )
-          )
-        )
-        Await.result(inspectTask.unsafeToFuture(), 3.seconds)
+    val result = withTestSpace { case TestFixture(_, reducer) =>
+      implicit val env = Env.makeEnv[Par]()
+      val inspectTask  = reducer.evalExpr(
+        EPlusPlusBody(
+          EPlusPlus(
+            GByteArray("dead".unsafeHexToByteString),
+            GByteArray("beef".unsafeHexToByteString),
+          ),
+        ),
+      )
+      Await.result(inspectTask.unsafeToFuture(), 3.seconds)
     }
     result.exprs should be(
-      Seq(Expr(GByteArray("deadbeef".unsafeHexToByteString)))
+      Seq(Expr(GByteArray("deadbeef".unsafeHexToByteString))),
     )
   }
 
@@ -1456,357 +1394,176 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
     EPercentPercentBody(
       EPercentPercent(
         GString(base),
-        EMapBody(ParMap(substitutes))
-      )
+        EMapBody(ParMap(substitutes)),
+      ),
     )
 
   "'${a} ${b}' % {'a': '1 ${b}', 'b': '2 ${a}'" should "return '1 ${b} 2 ${a}" in {
-    val result = withTestSpace {
-      case TestFixture(_, reducer) =>
-        implicit val env = Env.makeEnv[Par]()
-        val inspectTask = reducer.evalExpr(
-          interpolate(
-            "${a} ${b}",
-            List[(Par, Par)](
-              (GString("a"), GString("1 ${b}")),
-              (GString("b"), GString("2 ${a}"))
-            )
-          )
-        )
-        Await.result(inspectTask.unsafeToFuture(), 3.seconds)
+    val result = withTestSpace { case TestFixture(_, reducer) =>
+      implicit val env = Env.makeEnv[Par]()
+      val inspectTask  = reducer.evalExpr(
+        interpolate(
+          "${a} ${b}",
+          List[(Par, Par)](
+            (GString("a"), GString("1 ${b}")),
+            (GString("b"), GString("2 ${a}")),
+          ),
+        ),
+      )
+      Await.result(inspectTask.unsafeToFuture(), 3.seconds)
     }
     result.exprs should be(Seq(Expr(GString("1 ${b} 2 ${a}"))))
   }
 
   "interpolate" should "interpolate Boolean values" in {
-    val result = withTestSpace {
-      case TestFixture(_, reducer) =>
-        implicit val env = Env.makeEnv[Par]()
-        val task = reducer.evalExpr(
-          interpolate(
-            "${a} ${b}",
-            Seq[(Par, Par)](
-              (GString("a"), GBool(false)),
-              (GString("b"), GBool(true))
-            )
-          )
-        )
-        Await.result(task.unsafeToFuture(), 3.seconds)
+    val result = withTestSpace { case TestFixture(_, reducer) =>
+      implicit val env = Env.makeEnv[Par]()
+      val task         = reducer.evalExpr(
+        interpolate(
+          "${a} ${b}",
+          Seq[(Par, Par)](
+            (GString("a"), GBool(false)),
+            (GString("b"), GBool(true)),
+          ),
+        ),
+      )
+      Await.result(task.unsafeToFuture(), 3.seconds)
     }
 
     result.exprs should be(Seq(Expr(GString("false true"))))
   }
 
   "interpolate" should "interpolate URIs" in {
-    val result = withTestSpace {
-      case TestFixture(_, reducer) =>
-        implicit val env = Env.makeEnv[Par]()
-        val task = reducer.evalExpr(
-          interpolate(
-            "${a} ${b}",
-            Seq[(Par, Par)](
-              (GString("a"), GUri("testUriA")),
-              (GString("b"), GUri("testUriB"))
-            )
-          )
-        )
-        Await.result(task.unsafeToFuture(), 3.seconds)
+    val result = withTestSpace { case TestFixture(_, reducer) =>
+      implicit val env = Env.makeEnv[Par]()
+      val task         = reducer.evalExpr(
+        interpolate(
+          "${a} ${b}",
+          Seq[(Par, Par)](
+            (GString("a"), GUri("testUriA")),
+            (GString("b"), GUri("testUriB")),
+          ),
+        ),
+      )
+      Await.result(task.unsafeToFuture(), 3.seconds)
     }
 
     result.exprs should be(Seq(Expr(GString("testUriA testUriB"))))
   }
 
   "[0, 1, 2, 3].length()" should "return the length of the list" in {
-    val result = withTestSpace {
-      case TestFixture(_, reducer) =>
-        implicit val env = Env.makeEnv[Par]()
-        val list         = EList(List(GInt(0L), GInt(1L), GInt(2L), GInt(3L)))
-        val inspectTask  = reducer.evalExpr(EMethodBody(EMethod("length", list)))
+    val result = withTestSpace { case TestFixture(_, reducer) =>
+      implicit val env = Env.makeEnv[Par]()
+      val list         = EList(List(GInt(0L), GInt(1L), GInt(2L), GInt(3L)))
+      val inspectTask  = reducer.evalExpr(EMethodBody(EMethod("length", list)))
 
-        Await.result(inspectTask.unsafeToFuture(), 3.seconds)
+      Await.result(inspectTask.unsafeToFuture(), 3.seconds)
     }
     result.exprs should be(Seq(Expr(GInt(4L))))
   }
 
   "[3, 7, 2, 9, 4, 3, 7].slice(3, 5)" should "return [9, 4]" in {
-    val result = withTestSpace {
-      case TestFixture(_, reducer) =>
-        implicit val env = Env.makeEnv[Par]()
-        val list         = EList(List(GInt(3L), GInt(7L), GInt(2L), GInt(9L), GInt(4L), GInt(3L), GInt(7L)))
-        val inspectTask = reducer.evalExpr(
-          EMethodBody(EMethod("slice", list, List(GInt(3L), GInt(5L))))
-        )
-        Await.result(inspectTask.unsafeToFuture(), 3.seconds)
+    val result = withTestSpace { case TestFixture(_, reducer) =>
+      implicit val env = Env.makeEnv[Par]()
+      val list         = EList(List(GInt(3L), GInt(7L), GInt(2L), GInt(9L), GInt(4L), GInt(3L), GInt(7L)))
+      val inspectTask  = reducer.evalExpr(
+        EMethodBody(EMethod("slice", list, List(GInt(3L), GInt(5L)))),
+      )
+      Await.result(inspectTask.unsafeToFuture(), 3.seconds)
     }
     result.exprs should be(Seq(Expr(EListBody(EList(List(GInt(9L), GInt(4L)))))))
   }
 
   "[3, 7, 2, 9, 4, 3, 7].slice(5, 4)" should "return []" in {
-    val result = withTestSpace {
-      case TestFixture(_, reducer) =>
-        implicit val env = Env.makeEnv[Par]()
-        val list         = EList(List(GInt(3L), GInt(7L), GInt(2L), GInt(9L), GInt(4L), GInt(3L), GInt(7L)))
-        val inspectTask = reducer.evalExpr(
-          EMethodBody(EMethod("slice", list, List(GInt(5L), GInt(4L))))
-        )
-        Await.result(inspectTask.unsafeToFuture(), 3.seconds)
+    val result = withTestSpace { case TestFixture(_, reducer) =>
+      implicit val env = Env.makeEnv[Par]()
+      val list         = EList(List(GInt(3L), GInt(7L), GInt(2L), GInt(9L), GInt(4L), GInt(3L), GInt(7L)))
+      val inspectTask  = reducer.evalExpr(
+        EMethodBody(EMethod("slice", list, List(GInt(5L), GInt(4L)))),
+      )
+      Await.result(inspectTask.unsafeToFuture(), 3.seconds)
     }
     result.exprs should be(Seq(Expr(EListBody(EList(List())))))
   }
 
   "[3, 7, 2, 9, 4, 3, 7].slice(7, 8)" should "return []" in {
-    val result = withTestSpace {
-      case TestFixture(_, reducer) =>
-        implicit val env = Env.makeEnv[Par]()
-        val list         = EList(List(GInt(3L), GInt(7L), GInt(2L), GInt(9L), GInt(4L), GInt(3L), GInt(7L)))
-        val inspectTask = reducer.evalExpr(
-          EMethodBody(EMethod("slice", list, List(GInt(7L), GInt(8L))))
-        )
-        Await.result(inspectTask.unsafeToFuture(), 3.seconds)
+    val result = withTestSpace { case TestFixture(_, reducer) =>
+      implicit val env = Env.makeEnv[Par]()
+      val list         = EList(List(GInt(3L), GInt(7L), GInt(2L), GInt(9L), GInt(4L), GInt(3L), GInt(7L)))
+      val inspectTask  = reducer.evalExpr(
+        EMethodBody(EMethod("slice", list, List(GInt(7L), GInt(8L)))),
+      )
+      Await.result(inspectTask.unsafeToFuture(), 3.seconds)
     }
     result.exprs should be(Seq(Expr(EListBody(EList(List())))))
   }
 
   "[3, 7, 2, 9, 4, 3, 7].slice(-2, 2)" should "return [3, 7]" in {
-    val result = withTestSpace {
-      case TestFixture(_, reducer) =>
-        implicit val env = Env.makeEnv[Par]()
-        val list         = EList(List(GInt(3L), GInt(7L), GInt(2L), GInt(9L), GInt(4L), GInt(3L), GInt(7L)))
-        val inspectTask = reducer.evalExpr(
-          EMethodBody(EMethod("slice", list, List(GInt(-2L), GInt(2L))))
-        )
-        Await.result(inspectTask.unsafeToFuture(), 3.seconds)
+    val result = withTestSpace { case TestFixture(_, reducer) =>
+      implicit val env = Env.makeEnv[Par]()
+      val list         = EList(List(GInt(3L), GInt(7L), GInt(2L), GInt(9L), GInt(4L), GInt(3L), GInt(7L)))
+      val inspectTask  = reducer.evalExpr(
+        EMethodBody(EMethod("slice", list, List(GInt(-2L), GInt(2L)))),
+      )
+      Await.result(inspectTask.unsafeToFuture(), 3.seconds)
     }
     result.exprs should be(Seq(Expr(EListBody(EList(List(GInt(3L), GInt(7L)))))))
   }
 
   "[3, 2, 9] ++ [6, 1, 7]" should "return [3, 2, 9, 6, 1, 7]" in {
-    val result = withTestSpace {
-      case TestFixture(_, reducer) =>
-        implicit val env = Env.makeEnv[Par]()
-        val lhsList      = EList(List(GInt(3L), GInt(2L), GInt(9L)))
-        val rhsList      = EList(List(GInt(6L), GInt(1L), GInt(7L)))
-        val inspectTask = reducer.evalExpr(
-          EPlusPlusBody(
-            EPlusPlus(
-              lhsList,
-              rhsList
-            )
-          )
-        )
-        Await.result(inspectTask.unsafeToFuture(), 3.seconds)
+    val result     = withTestSpace { case TestFixture(_, reducer) =>
+      implicit val env = Env.makeEnv[Par]()
+      val lhsList      = EList(List(GInt(3L), GInt(2L), GInt(9L)))
+      val rhsList      = EList(List(GInt(6L), GInt(1L), GInt(7L)))
+      val inspectTask  = reducer.evalExpr(
+        EPlusPlusBody(
+          EPlusPlus(
+            lhsList,
+            rhsList,
+          ),
+        ),
+      )
+      Await.result(inspectTask.unsafeToFuture(), 3.seconds)
     }
     val resultList = EList(List(GInt(3L), GInt(2L), GInt(9L), GInt(6L), GInt(1L), GInt(7L)))
     result.exprs should be(Seq(Expr(EListBody(resultList))))
   }
 
   "{1: 'a', 2: 'b'}.getOrElse(1, 'c')" should "return 'a'" in {
-    val result = withTestSpace {
-      case TestFixture(_, reducer) =>
-        implicit val env = Env.makeEnv[Par]()
-        val map =
-          EMapBody(ParMap(List[(Par, Par)]((GInt(1L), GString("a")), (GInt(2L), GString("b")))))
-        val inspectTask = reducer.evalExpr(
-          EMethodBody(EMethod("getOrElse", map, List(GInt(1L), GString("c"))))
-        )
-        Await.result(inspectTask.unsafeToFuture(), 3.seconds)
+    val result = withTestSpace { case TestFixture(_, reducer) =>
+      implicit val env = Env.makeEnv[Par]()
+      val map          =
+        EMapBody(ParMap(List[(Par, Par)]((GInt(1L), GString("a")), (GInt(2L), GString("b")))))
+      val inspectTask  = reducer.evalExpr(
+        EMethodBody(EMethod("getOrElse", map, List(GInt(1L), GString("c")))),
+      )
+      Await.result(inspectTask.unsafeToFuture(), 3.seconds)
     }
     result.exprs should be(Seq(Expr(GString("a"))))
   }
 
   "{1: 'a', 2: 'b'}.getOrElse(3, 'c')" should "return 'c'" in {
-    val result = withTestSpace {
-      case TestFixture(_, reducer) =>
-        implicit val env = Env.makeEnv[Par]()
-        val map =
-          EMapBody(ParMap(List[(Par, Par)]((GInt(1L), GString("a")), (GInt(2L), GString("b")))))
-        val inspectTask = reducer.evalExpr(
-          EMethodBody(EMethod("getOrElse", map, List(GInt(3L), GString("c"))))
-        )
-        Await.result(inspectTask.unsafeToFuture(), 3.seconds)
+    val result = withTestSpace { case TestFixture(_, reducer) =>
+      implicit val env = Env.makeEnv[Par]()
+      val map          =
+        EMapBody(ParMap(List[(Par, Par)]((GInt(1L), GString("a")), (GInt(2L), GString("b")))))
+      val inspectTask  = reducer.evalExpr(
+        EMethodBody(EMethod("getOrElse", map, List(GInt(3L), GString("c")))),
+      )
+      Await.result(inspectTask.unsafeToFuture(), 3.seconds)
     }
     result.exprs should be(Seq(Expr(GString("c"))))
   }
 
   "{1: 'a', 2: 'b'}.set(3, 'c')" should "return {1: 'a', 2: 'b', 3: 'c'}" in {
-    val result = withTestSpace {
-      case TestFixture(_, reducer) =>
-        implicit val env = Env.makeEnv[Par]()
-        val map =
-          EMapBody(ParMap(List[(Par, Par)]((GInt(1L), GString("a")), (GInt(2L), GString("b")))))
-        val inspectTask = reducer.evalExpr(
-          EMethodBody(EMethod("set", map, List(GInt(3L), GString("c"))))
-        )
-        Await.result(inspectTask.unsafeToFuture(), 3.seconds)
-    }
-    val resultMap = EMapBody(
-      ParMap(
-        List[(Par, Par)](
-          (GInt(1L), GString("a")),
-          (GInt(2L), GString("b")),
-          (GInt(3L), GString("c"))
-        )
+    val result    = withTestSpace { case TestFixture(_, reducer) =>
+      implicit val env = Env.makeEnv[Par]()
+      val map          =
+        EMapBody(ParMap(List[(Par, Par)]((GInt(1L), GString("a")), (GInt(2L), GString("b")))))
+      val inspectTask  = reducer.evalExpr(
+        EMethodBody(EMethod("set", map, List(GInt(3L), GString("c")))),
       )
-    )
-    result.exprs should be(Seq(Expr(resultMap)))
-  }
-
-  "{1: 'a', 2: 'b'}.set(2, 'c')" should "return {1: 'a', 2: 'c'}" in {
-    val result = withTestSpace {
-      case TestFixture(_, reducer) =>
-        implicit val env = Env.makeEnv[Par]()
-        val map =
-          EMapBody(ParMap(List[(Par, Par)]((GInt(1L), GString("a")), (GInt(2L), GString("b")))))
-        val inspectTask = reducer.evalExpr(
-          EMethodBody(EMethod("set", map, List(GInt(2L), GString("c"))))
-        )
-        Await.result(inspectTask.unsafeToFuture(), 3.seconds)
-    }
-    val resultMap =
-      EMapBody(ParMap(List[(Par, Par)]((GInt(1L), GString("a")), (GInt(2L), GString("c")))))
-    result.exprs should be(Seq(Expr(resultMap)))
-  }
-
-  "{1: 'a', 2: 'b', 3: 'c'}.keys()" should "return Set(1, 2, 3)" in {
-    val result = withTestSpace {
-      case TestFixture(_, reducer) =>
-        implicit val env = Env.makeEnv[Par]()
-        val map = EMapBody(
-          ParMap(
-            List[(Par, Par)](
-              (GInt(1L), GString("a")),
-              (GInt(2L), GString("b")),
-              (GInt(3L), GString("c"))
-            )
-          )
-        )
-        val inspectTask = reducer.evalExpr(
-          EMethodBody(EMethod("keys", map))
-        )
-        Await.result(inspectTask.unsafeToFuture(), 3.seconds)
-    }
-    val resultSet = ESetBody(
-      ParSet(
-        List[Par](GInt(1L), GInt(2L), GInt(3L))
-      )
-    )
-    result.exprs should be(Seq(Expr(resultSet)))
-  }
-
-  "{1: 'a', 2: 'b', 3: 'c'}.size()" should "return 3" in {
-    val result = withTestSpace {
-      case TestFixture(_, reducer) =>
-        implicit val env = Env.makeEnv[Par]()
-        val map = EMapBody(
-          ParMap(
-            List[(Par, Par)](
-              (GInt(1L), GString("a")),
-              (GInt(2L), GString("b")),
-              (GInt(3L), GString("c"))
-            )
-          )
-        )
-        val inspectTask = reducer.evalExpr(
-          EMethodBody(EMethod("size", map))
-        )
-        Await.result(inspectTask.unsafeToFuture(), 3.seconds)
-    }
-    result.exprs should be(Seq(Expr(GInt(3L))))
-  }
-
-  "Set(1, 2, 3).size()" should "return 3" in {
-    val result = withTestSpace {
-      case TestFixture(_, reducer) =>
-        implicit val env = Env.makeEnv[Par]()
-
-        val set = ESetBody(ParSet(List[Par](GInt(1L), GInt(2L), GInt(3L))))
-        val inspectTask = reducer.evalExpr(
-          EMethodBody(EMethod("size", set))
-        )
-
-        Await.result(inspectTask.unsafeToFuture(), 3.seconds)
-    }
-    result.exprs should be(Seq(Expr(GInt(3L))))
-  }
-
-  "Set(1, 2) + 3" should "return Set(1, 2, 3)" in {
-    val result = withTestSpace {
-      case TestFixture(_, reducer) =>
-        implicit val env = Env.makeEnv[Par]()
-        val set          = ESetBody(ParSet(List[Par](GInt(1L), GInt(2L))))
-        val inspectTask = reducer.evalExpr(
-          EPlusBody(EPlus(set, GInt(3L)))
-        )
-        Await.result(inspectTask.unsafeToFuture(), 3.seconds)
-    }
-    val resultSet = ESetBody(ParSet(List[Par](GInt(1L), GInt(2L), GInt(3L))))
-    result.exprs should be(Seq(Expr(resultSet)))
-  }
-
-  "{1: 'a', 2: 'b', 3: 'c'} - 3" should "return {1: 'a', 2: 'b'}" in {
-    val result = withTestSpace {
-      case TestFixture(_, reducer) =>
-        implicit val env = Env.makeEnv[Par]()
-        val map = EMapBody(
-          ParMap(
-            List[(Par, Par)](
-              (GInt(1L), GString("a")),
-              (GInt(2L), GString("b")),
-              (GInt(3L), GString("c"))
-            )
-          )
-        )
-        val inspectTask = reducer.evalExpr(
-          EMinusBody(EMinus(map, GInt(3L)))
-        )
-        Await.result(inspectTask.unsafeToFuture(), 3.seconds)
-    }
-    val resultMap =
-      EMapBody(ParMap(List[(Par, Par)]((GInt(1L), GString("a")), (GInt(2L), GString("b")))))
-    result.exprs should be(Seq(Expr(resultMap)))
-  }
-
-  "Set(1, 2, 3) - 3" should "return Set(1, 2)" in {
-    val result = withTestSpace {
-      case TestFixture(_, reducer) =>
-        implicit val env = Env.makeEnv[Par]()
-        val set          = ESetBody(ParSet(List[Par](GInt(1L), GInt(2L), GInt(3L))))
-        val inspectTask = reducer.evalExpr(
-          EMinusBody(EMinus(set, GInt(3L)))
-        )
-        Await.result(inspectTask.unsafeToFuture(), 3.seconds)
-    }
-    val resultSet = ESetBody(ParSet(List[Par](GInt(1L), GInt(2L))))
-    result.exprs should be(Seq(Expr(resultSet)))
-  }
-
-  "Set(1, 2) ++ Set(3, 4)" should "return Set(1, 2, 3, 4)" in {
-    val result = withTestSpace {
-      case TestFixture(_, reducer) =>
-        implicit val env = Env.makeEnv[Par]()
-        val lhsSet       = ESetBody(ParSet(List[Par](GInt(1L), GInt(2L))))
-        val rhsSet       = ESetBody(ParSet(List[Par](GInt(3L), GInt(4L))))
-        val inspectTask = reducer.evalExpr(
-          EPlusPlusBody(EPlusPlus(lhsSet, rhsSet))
-        )
-        Await.result(inspectTask.unsafeToFuture(), 3.seconds)
-    }
-    val resultSet = ESetBody(ParSet(List[Par](GInt(1L), GInt(2L), GInt(3L), GInt(4L))))
-    result.exprs should be(Seq(Expr(resultSet)))
-  }
-
-  "{1: 'a', 2: 'b'} ++ {3: 'c', 4: 'd'}" should "return union" in {
-    val result = withTestSpace {
-      case TestFixture(_, reducer) =>
-        implicit val env = Env.makeEnv[Par]()
-        val lhsMap =
-          EMapBody(ParMap(List[(Par, Par)]((GInt(1L), GString("a")), (GInt(2L), GString("b")))))
-        val rhsMap =
-          EMapBody(ParMap(List[(Par, Par)]((GInt(3L), GString("c")), (GInt(4L), GString("d")))))
-        val inspectTask = reducer.evalExpr(
-          EPlusPlusBody(EPlusPlus(lhsMap, rhsMap))
-        )
-        Await.result(inspectTask.unsafeToFuture(), 3.seconds)
+      Await.result(inspectTask.unsafeToFuture(), 3.seconds)
     }
     val resultMap = EMapBody(
       ParMap(
@@ -1814,47 +1571,204 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
           (GInt(1L), GString("a")),
           (GInt(2L), GString("b")),
           (GInt(3L), GString("c")),
-          (GInt(4L), GString("d"))
-        )
+        ),
+      ),
+    )
+    result.exprs should be(Seq(Expr(resultMap)))
+  }
+
+  "{1: 'a', 2: 'b'}.set(2, 'c')" should "return {1: 'a', 2: 'c'}" in {
+    val result    = withTestSpace { case TestFixture(_, reducer) =>
+      implicit val env = Env.makeEnv[Par]()
+      val map          =
+        EMapBody(ParMap(List[(Par, Par)]((GInt(1L), GString("a")), (GInt(2L), GString("b")))))
+      val inspectTask  = reducer.evalExpr(
+        EMethodBody(EMethod("set", map, List(GInt(2L), GString("c")))),
       )
+      Await.result(inspectTask.unsafeToFuture(), 3.seconds)
+    }
+    val resultMap =
+      EMapBody(ParMap(List[(Par, Par)]((GInt(1L), GString("a")), (GInt(2L), GString("c")))))
+    result.exprs should be(Seq(Expr(resultMap)))
+  }
+
+  "{1: 'a', 2: 'b', 3: 'c'}.keys()" should "return Set(1, 2, 3)" in {
+    val result    = withTestSpace { case TestFixture(_, reducer) =>
+      implicit val env = Env.makeEnv[Par]()
+      val map          = EMapBody(
+        ParMap(
+          List[(Par, Par)](
+            (GInt(1L), GString("a")),
+            (GInt(2L), GString("b")),
+            (GInt(3L), GString("c")),
+          ),
+        ),
+      )
+      val inspectTask  = reducer.evalExpr(
+        EMethodBody(EMethod("keys", map)),
+      )
+      Await.result(inspectTask.unsafeToFuture(), 3.seconds)
+    }
+    val resultSet = ESetBody(
+      ParSet(
+        List[Par](GInt(1L), GInt(2L), GInt(3L)),
+      ),
+    )
+    result.exprs should be(Seq(Expr(resultSet)))
+  }
+
+  "{1: 'a', 2: 'b', 3: 'c'}.size()" should "return 3" in {
+    val result = withTestSpace { case TestFixture(_, reducer) =>
+      implicit val env = Env.makeEnv[Par]()
+      val map          = EMapBody(
+        ParMap(
+          List[(Par, Par)](
+            (GInt(1L), GString("a")),
+            (GInt(2L), GString("b")),
+            (GInt(3L), GString("c")),
+          ),
+        ),
+      )
+      val inspectTask  = reducer.evalExpr(
+        EMethodBody(EMethod("size", map)),
+      )
+      Await.result(inspectTask.unsafeToFuture(), 3.seconds)
+    }
+    result.exprs should be(Seq(Expr(GInt(3L))))
+  }
+
+  "Set(1, 2, 3).size()" should "return 3" in {
+    val result = withTestSpace { case TestFixture(_, reducer) =>
+      implicit val env = Env.makeEnv[Par]()
+
+      val set         = ESetBody(ParSet(List[Par](GInt(1L), GInt(2L), GInt(3L))))
+      val inspectTask = reducer.evalExpr(
+        EMethodBody(EMethod("size", set)),
+      )
+
+      Await.result(inspectTask.unsafeToFuture(), 3.seconds)
+    }
+    result.exprs should be(Seq(Expr(GInt(3L))))
+  }
+
+  "Set(1, 2) + 3" should "return Set(1, 2, 3)" in {
+    val result    = withTestSpace { case TestFixture(_, reducer) =>
+      implicit val env = Env.makeEnv[Par]()
+      val set          = ESetBody(ParSet(List[Par](GInt(1L), GInt(2L))))
+      val inspectTask  = reducer.evalExpr(
+        EPlusBody(EPlus(set, GInt(3L))),
+      )
+      Await.result(inspectTask.unsafeToFuture(), 3.seconds)
+    }
+    val resultSet = ESetBody(ParSet(List[Par](GInt(1L), GInt(2L), GInt(3L))))
+    result.exprs should be(Seq(Expr(resultSet)))
+  }
+
+  "{1: 'a', 2: 'b', 3: 'c'} - 3" should "return {1: 'a', 2: 'b'}" in {
+    val result    = withTestSpace { case TestFixture(_, reducer) =>
+      implicit val env = Env.makeEnv[Par]()
+      val map          = EMapBody(
+        ParMap(
+          List[(Par, Par)](
+            (GInt(1L), GString("a")),
+            (GInt(2L), GString("b")),
+            (GInt(3L), GString("c")),
+          ),
+        ),
+      )
+      val inspectTask  = reducer.evalExpr(
+        EMinusBody(EMinus(map, GInt(3L))),
+      )
+      Await.result(inspectTask.unsafeToFuture(), 3.seconds)
+    }
+    val resultMap =
+      EMapBody(ParMap(List[(Par, Par)]((GInt(1L), GString("a")), (GInt(2L), GString("b")))))
+    result.exprs should be(Seq(Expr(resultMap)))
+  }
+
+  "Set(1, 2, 3) - 3" should "return Set(1, 2)" in {
+    val result    = withTestSpace { case TestFixture(_, reducer) =>
+      implicit val env = Env.makeEnv[Par]()
+      val set          = ESetBody(ParSet(List[Par](GInt(1L), GInt(2L), GInt(3L))))
+      val inspectTask  = reducer.evalExpr(
+        EMinusBody(EMinus(set, GInt(3L))),
+      )
+      Await.result(inspectTask.unsafeToFuture(), 3.seconds)
+    }
+    val resultSet = ESetBody(ParSet(List[Par](GInt(1L), GInt(2L))))
+    result.exprs should be(Seq(Expr(resultSet)))
+  }
+
+  "Set(1, 2) ++ Set(3, 4)" should "return Set(1, 2, 3, 4)" in {
+    val result    = withTestSpace { case TestFixture(_, reducer) =>
+      implicit val env = Env.makeEnv[Par]()
+      val lhsSet       = ESetBody(ParSet(List[Par](GInt(1L), GInt(2L))))
+      val rhsSet       = ESetBody(ParSet(List[Par](GInt(3L), GInt(4L))))
+      val inspectTask  = reducer.evalExpr(
+        EPlusPlusBody(EPlusPlus(lhsSet, rhsSet)),
+      )
+      Await.result(inspectTask.unsafeToFuture(), 3.seconds)
+    }
+    val resultSet = ESetBody(ParSet(List[Par](GInt(1L), GInt(2L), GInt(3L), GInt(4L))))
+    result.exprs should be(Seq(Expr(resultSet)))
+  }
+
+  "{1: 'a', 2: 'b'} ++ {3: 'c', 4: 'd'}" should "return union" in {
+    val result    = withTestSpace { case TestFixture(_, reducer) =>
+      implicit val env = Env.makeEnv[Par]()
+      val lhsMap       =
+        EMapBody(ParMap(List[(Par, Par)]((GInt(1L), GString("a")), (GInt(2L), GString("b")))))
+      val rhsMap       =
+        EMapBody(ParMap(List[(Par, Par)]((GInt(3L), GString("c")), (GInt(4L), GString("d")))))
+      val inspectTask  = reducer.evalExpr(
+        EPlusPlusBody(EPlusPlus(lhsMap, rhsMap)),
+      )
+      Await.result(inspectTask.unsafeToFuture(), 3.seconds)
+    }
+    val resultMap = EMapBody(
+      ParMap(
+        List[(Par, Par)](
+          (GInt(1L), GString("a")),
+          (GInt(2L), GString("b")),
+          (GInt(3L), GString("c")),
+          (GInt(4L), GString("d")),
+        ),
+      ),
     )
     result.exprs should be(Seq(Expr(resultMap)))
   }
 
   "Set(1, 2, 3, 4) -- Set(1, 2)" should "return Set(3, 4)" in {
-    val result = withTestSpace {
-      case TestFixture(_, reducer) =>
-        implicit val env = Env.makeEnv[Par]()
-        val lhsSet       = ESetBody(ParSet(List[Par](GInt(1L), GInt(2L), GInt(3L), GInt(4L))))
-        val rhsSet       = ESetBody(ParSet(List[Par](GInt(1L), GInt(2L))))
-        val inspectTask = reducer.evalExpr(
-          EMinusMinusBody(EMinusMinus(lhsSet, rhsSet))
-        )
-        Await.result(inspectTask.unsafeToFuture(), 3.seconds)
+    val result    = withTestSpace { case TestFixture(_, reducer) =>
+      implicit val env = Env.makeEnv[Par]()
+      val lhsSet       = ESetBody(ParSet(List[Par](GInt(1L), GInt(2L), GInt(3L), GInt(4L))))
+      val rhsSet       = ESetBody(ParSet(List[Par](GInt(1L), GInt(2L))))
+      val inspectTask  = reducer.evalExpr(
+        EMinusMinusBody(EMinusMinus(lhsSet, rhsSet)),
+      )
+      Await.result(inspectTask.unsafeToFuture(), 3.seconds)
     }
     val resultSet = ESetBody(ParSet(List[Par](GInt(3L), GInt(4L))))
     result.exprs should be(Seq(Expr(resultSet)))
   }
 
   "Set(1, 2, 3).get(1)" should "not work" in {
-    val result = withTestSpace {
-      case TestFixture(_, reducer) =>
-        implicit val env = Env.makeEnv[Par]()
-        val set          = ESetBody(ParSet(List[Par](GInt(1L), GInt(2L), GInt(3L))))
-        val inspectTask  = reducer.eval(EMethodBody(EMethod("get", set, List(GInt(1L)))))
-        Await.ready(inspectTask.unsafeToFuture(), 3.seconds)
+    val result = withTestSpace { case TestFixture(_, reducer) =>
+      implicit val env = Env.makeEnv[Par]()
+      val set          = ESetBody(ParSet(List[Par](GInt(1L), GInt(2L), GInt(3L))))
+      val inspectTask  = reducer.eval(EMethodBody(EMethod("get", set, List(GInt(1L)))))
+      Await.ready(inspectTask.unsafeToFuture(), 3.seconds)
     }
     result.value shouldBe Failure(MethodNotDefined("get", "Set")).some
   }
 
   "{1: 'a', 2: 'b'}.add(1)" should "not work" in {
-    val result = withTestSpace {
-      case TestFixture(_, reducer) =>
-        implicit val env = Env.makeEnv[Par]()
-        val map =
-          EMapBody(ParMap(List[(Par, Par)]((GInt(1L), GString("a")), (GInt(2L), GString("b")))))
-        val inspectTask = reducer.eval(EMethodBody(EMethod("add", map, List(GInt(1L)))))
-        Await.ready(inspectTask.unsafeToFuture(), 3.seconds)
+    val result = withTestSpace { case TestFixture(_, reducer) =>
+      implicit val env = Env.makeEnv[Par]()
+      val map          =
+        EMapBody(ParMap(List[(Par, Par)]((GInt(1L), GString("a")), (GInt(2L), GString("b")))))
+      val inspectTask  = reducer.eval(EMethodBody(EMethod("add", map, List(GInt(1L)))))
+      Await.ready(inspectTask.unsafeToFuture(), 3.seconds)
     }
     result.value shouldBe Failure(MethodNotDefined("add", "Map")).some
   }
@@ -1864,15 +1778,14 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
       EMethod(
         "toList",
         EList(List()),
-        List[Par](GInt(1L))
+        List[Par](GInt(1L)),
       )
 
-    val result = withTestSpace {
-      case TestFixture(space, reducer) =>
-        implicit val env = Env[Par]()
-        val nthTask      = reducer.eval(toListCall)
-        val inspectTask  = nthTask >> space.toMap
-        Await.ready(inspectTask.unsafeToFuture(), 3.seconds)
+    val result = withTestSpace { case TestFixture(space, reducer) =>
+      implicit val env = Env[Par]()
+      val nthTask      = reducer.eval(toListCall)
+      val inspectTask  = nthTask >> space.toMap
+      Await.ready(inspectTask.unsafeToFuture(), 3.seconds)
     }
     result.value shouldBe Failure(MethodArgumentNumberMismatch("toList", 0, 1)).some
   }
@@ -1886,28 +1799,27 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
             List(
               GInt(1L),
               GInt(2L),
-              GInt(3L)
-            )
-          )
+              GInt(3L),
+            ),
+          ),
         ),
-        List[Par]()
+        List[Par](),
       )
 
-    val result: Par = withTestSpace {
-      case TestFixture(_, reducer) =>
-        implicit val env: Env[Par] = Env[Par]()
-        val toListTask             = reducer.evalExpr(toListCall)
-        Await.result(toListTask.unsafeToFuture(), 3.seconds)
+    val result: Par = withTestSpace { case TestFixture(_, reducer) =>
+      implicit val env: Env[Par] = Env[Par]()
+      val toListTask             = reducer.evalExpr(toListCall)
+      Await.result(toListTask.unsafeToFuture(), 3.seconds)
     }
-    val resultList =
+    val resultList  =
       EListBody(
         EList(
           List[Par](
             GInt(1L),
             GInt(2L),
-            GInt(3L)
-          )
-        )
+            GInt(3L),
+          ),
+        ),
       )
     result.exprs should be(Seq(Expr(resultList)))
   }
@@ -1921,27 +1833,26 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
             List[(Par, Par)](
               (GString("a"), GInt(1L)),
               (GString("b"), GInt(2L)),
-              (GString("c"), GInt(3L))
-            )
-          )
+              (GString("c"), GInt(3L)),
+            ),
+          ),
         ),
-        List[Par]()
+        List[Par](),
       )
-    val result: Par = withTestSpace {
-      case TestFixture(_, reducer) =>
-        implicit val env: Env[Par] = Env[Par]()
-        val toListTask             = reducer.evalExpr(toListCall)
-        Await.result(toListTask.unsafeToFuture(), 3.seconds)
+    val result: Par         = withTestSpace { case TestFixture(_, reducer) =>
+      implicit val env: Env[Par] = Env[Par]()
+      val toListTask             = reducer.evalExpr(toListCall)
+      Await.result(toListTask.unsafeToFuture(), 3.seconds)
     }
-    val resultList =
+    val resultList          =
       EListBody(
         EList(
           List[Par](
             ETupleBody(ETuple(Seq(GString("a"), GInt(1L)))),
             ETupleBody(ETuple(Seq(GString("b"), GInt(2L)))),
-            ETupleBody(ETuple(Seq(GString("c"), GInt(3L))))
-          )
-        )
+            ETupleBody(ETuple(Seq(GString("c"), GInt(3L)))),
+          ),
+        ),
       )
     result.exprs should be(Seq(Expr(resultList)))
   }
@@ -1955,27 +1866,26 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
             List[Par](
               GInt(1L),
               GInt(2L),
-              GInt(3L)
-            )
-          )
+              GInt(3L),
+            ),
+          ),
         ),
-        List[Par]()
+        List[Par](),
       )
-    val result: Par = withTestSpace {
-      case TestFixture(_, reducer) =>
-        implicit val env: Env[Par] = Env[Par]()
-        val toListTask             = reducer.evalExpr(toListCall)
-        Await.result(toListTask.unsafeToFuture(), 3.seconds)
+    val result: Par         = withTestSpace { case TestFixture(_, reducer) =>
+      implicit val env: Env[Par] = Env[Par]()
+      val toListTask             = reducer.evalExpr(toListCall)
+      Await.result(toListTask.unsafeToFuture(), 3.seconds)
     }
-    val resultList =
+    val resultList          =
       EListBody(
         EList(
           List[Par](
             GInt(1L),
             GInt(2L),
-            GInt(3L)
-          )
-        )
+            GInt(3L),
+          ),
+        ),
       )
     result.exprs should be(Seq(Expr(resultList)))
   }
@@ -1991,21 +1901,21 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
             List[Par](
               GInt(1L),
               GInt(2L),
-              GInt(3L)
-            )
-          )
+              GInt(3L),
+            ),
+          ),
         ),
-        List[Par]()
+        List[Par](),
       ),
       ESetBody(
         ParSet(
           List(
             GInt(1L),
             GInt(2L),
-            GInt(3L)
-          )
-        )
-      )
+            GInt(3L),
+          ),
+        ),
+      ),
     ),
     (
       "[1, 1].toSet() => Set(1)",
@@ -2015,19 +1925,19 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
           EList(
             List[Par](
               GInt(1L),
-              GInt(1L)
-            )
-          )
+              GInt(1L),
+            ),
+          ),
         ),
-        List[Par]()
+        List[Par](),
       ),
       ESetBody(
         ParSet(
           List(
-            GInt(1L)
-          )
-        )
-      )
+            GInt(1L),
+          ),
+        ),
+      ),
     ),
     (
       "[].toSet() => Set()",
@@ -2036,17 +1946,17 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
         EListBody(
           EList(
             List[Par](
-              )
-          )
+            ),
+          ),
         ),
-        List()
+        List(),
       ),
       ESetBody(
         ParSet(
           List(
-            )
-        )
-      )
+          ),
+        ),
+      ),
     ),
     (
       """[("a",1), ("b",2), ("c",3)].toMap() => {"a":1, "b":2, "c":3}""",
@@ -2057,21 +1967,21 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
             List[Par](
               ETupleBody(ETuple(Seq(GString("a"), GInt(1L)))),
               ETupleBody(ETuple(Seq(GString("b"), GInt(2L)))),
-              ETupleBody(ETuple(Seq(GString("c"), GInt(3L))))
-            )
-          )
+              ETupleBody(ETuple(Seq(GString("c"), GInt(3L)))),
+            ),
+          ),
         ),
-        List[Par]()
+        List[Par](),
       ),
       EMapBody(
         ParMap(
           List[(Par, Par)](
             (GString("a"), GInt(1L)),
             (GString("b"), GInt(2L)),
-            (GString("c"), GInt(3L))
-          )
-        )
-      )
+            (GString("c"), GInt(3L)),
+          ),
+        ),
+      ),
     ),
     (
       """Set(("a",1), ("b",2), ("c",3)).toMap() => {"a":1, "b":2, "c":3}""",
@@ -2082,21 +1992,21 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
             List[Par](
               ETupleBody(ETuple(Seq(GString("a"), GInt(1L)))),
               ETupleBody(ETuple(Seq(GString("b"), GInt(2L)))),
-              ETupleBody(ETuple(Seq(GString("c"), GInt(3L))))
-            )
-          )
+              ETupleBody(ETuple(Seq(GString("c"), GInt(3L)))),
+            ),
+          ),
         ),
-        List[Par]()
+        List[Par](),
       ),
       EMapBody(
         ParMap(
           List[(Par, Par)](
             (GString("a"), GInt(1L)),
             (GString("b"), GInt(2L)),
-            (GString("c"), GInt(3L))
-          )
-        )
-      )
+            (GString("c"), GInt(3L)),
+          ),
+        ),
+      ),
     ),
     (
       """{"a":1, "b":2, "c":3}.toSet() => Set(("a",1), ("b",2), ("c",3))""",
@@ -2107,21 +2017,21 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
             List[(Par, Par)](
               (GString("a"), GInt(1L)),
               (GString("b"), GInt(2L)),
-              (GString("c"), GInt(3L))
-            )
-          )
+              (GString("c"), GInt(3L)),
+            ),
+          ),
         ),
-        List[Par]()
+        List[Par](),
       ),
       ESetBody(
         ParSet(
           List[Par](
             ETupleBody(ETuple(Seq(GString("a"), GInt(1L)))),
             ETupleBody(ETuple(Seq(GString("b"), GInt(2L)))),
-            ETupleBody(ETuple(Seq(GString("c"), GInt(3L))))
-          )
-        )
-      )
+            ETupleBody(ETuple(Seq(GString("c"), GInt(3L)))),
+          ),
+        ),
+      ),
     ),
     (
       """[("a",1), ("a",2)].toMap() => {"a":2)""",
@@ -2131,19 +2041,19 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
           EList(
             List[Par](
               ETupleBody(ETuple(Seq(GString("a"), GInt(1L)))),
-              ETupleBody(ETuple(Seq(GString("a"), GInt(2L))))
-            )
-          )
+              ETupleBody(ETuple(Seq(GString("a"), GInt(2L)))),
+            ),
+          ),
         ),
-        List[Par]()
+        List[Par](),
       ),
       EMapBody(
         ParMap(
           List[(Par, Par)](
-            (GString("a"), GInt(2L))
-          )
-        )
-      )
+            (GString("a"), GInt(2L)),
+          ),
+        ),
+      ),
     ),
     (
       """[].toMap() => {}""",
@@ -2152,25 +2062,25 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
         EListBody(
           EList(
             List[Par](
-              )
-          )
+            ),
+          ),
         ),
-        List()
+        List(),
       ),
       EMapBody(
         ParMap(
           List(
-            )
-        )
-      )
-    )
+          ),
+        ),
+      ),
+    ),
   )
 
   "Reducer" should "work correctly in succesful cases" in {
     forAll(successfulExamples) { (clue, input, output) =>
       val result = runReducer(input).map(_.exprs)
 
-      result should be(Right(Seq(Expr(output)))) withClue (clue)
+      result should be(Right(Seq(Expr(output)))) withClue clue
     }
   }
 
@@ -2183,10 +2093,10 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
           List(
             GInt(1L),
             GInt(2L),
-            GInt(3L)
-          )
-        )
-      )
+            GInt(3L),
+          ),
+        ),
+      ),
     ),
     (
       "toMap",
@@ -2195,11 +2105,11 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
           List[(Par, Par)](
             (GString("a"), GInt(1L)),
             (GString("b"), GInt(2L)),
-            (GString("c"), GInt(3L))
-          )
-        )
-      )
-    )
+            (GString("c"), GInt(3L)),
+          ),
+        ),
+      ),
+    ),
   )
   "Idempotent methods" should "return the input" in {
     forAll(idempotenceExamples) { (method, input) =>
@@ -2207,12 +2117,12 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
         EMethod(
           method,
           input,
-          List()
+          List(),
         )
 
       val result = runReducer(methodCall).map(_.exprs)
 
-      result should be(Right(Seq(Expr(input)))) withClue (s"$method should not change the object it is applied on")
+      result should be(Right(Seq(Expr(input)))) withClue s"$method should not change the object it is applied on"
     }
   }
 
@@ -2226,13 +2136,13 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
           EList(
             List[Par](
               GString("a"),
-              ETupleBody(ETuple(Seq(GString("b"), GInt(2L))))
-            )
-          )
+              ETupleBody(ETuple(Seq(GString("b"), GInt(2L)))),
+            ),
+          ),
         ),
-        List[Par]()
+        List[Par](),
       ),
-      MethodNotDefined("toMap", "types except List[(K,V)]")
+      MethodNotDefined("toMap", "types except List[(K,V)]"),
     ),
     (
       """[("a", 1)].toMap(1) => MethodArgumentNumberMismatch""",
@@ -2241,22 +2151,22 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
         EListBody(
           EList(
             List[Par](
-              ETupleBody(ETuple(Seq(GString("a"), GInt(1L))))
-            )
-          )
+              ETupleBody(ETuple(Seq(GString("a"), GInt(1L)))),
+            ),
+          ),
         ),
-        List(GInt(1))
+        List(GInt(1)),
       ),
-      MethodArgumentNumberMismatch("toMap", 0, 1)
+      MethodArgumentNumberMismatch("toMap", 0, 1),
     ),
     (
       "1.toMap() => MethodNotDefined",
       EMethod(
         "toMap",
         GInt(1L),
-        List()
+        List(),
       ),
-      MethodNotDefined("toMap", "Int")
+      MethodNotDefined("toMap", "Int"),
     ),
     (
       "[].toSet(1) => MethodArgumentNumberMismatch",
@@ -2265,27 +2175,27 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
         ESetBody(
           ParSet(
             List(
-              )
-          )
+            ),
+          ),
         ),
-        List(GInt(1))
+        List(GInt(1)),
       ),
-      MethodArgumentNumberMismatch("toSet", 0, 1)
+      MethodArgumentNumberMismatch("toSet", 0, 1),
     ),
     (
       "1.toSet() => MethodNotDefined",
       EMethod(
         "toSet",
         GInt(1L),
-        List()
+        List(),
       ),
-      MethodNotDefined("toSet", "Int")
-    )
+      MethodNotDefined("toSet", "Int"),
+    ),
   )
 
   "Reducer" should "return report errors in failure cases" in {
     forAll(errorExamples) { (clue, input, error) =>
-      runReducer(input) should be(Left(error)) withClue (clue)
+      runReducer(input) should be(Left(error)) withClue clue
     }
   }
 
@@ -2293,10 +2203,9 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
 
   def runReducer(input: Par, timeout: Duration = 3.seconds): Either[Throwable, Par] = {
     val task =
-      withTestSpace {
-        case TestFixture(_, reducer) =>
-          implicit val env: Env[Par] = Env[Par]()
-          reducer.evalExpr(input).attempt
+      withTestSpace { case TestFixture(_, reducer) =>
+        implicit val env: Env[Par] = Env[Par]()
+        reducer.evalExpr(input).attempt
       }
 
     task.unsafeRunSync()
@@ -2317,11 +2226,10 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
     val news = Seq.fill(Short.MaxValue)(p)
     val proc = Par(news = news)
 
-    val result = withTestSpace {
-      case TestFixture(_, reducer) =>
-        implicit val env = Env[Par]()
-        val task         = reducer.eval(proc)
-        Await.result(task.unsafeToFuture(), 30.seconds)
+    val result = withTestSpace { case TestFixture(_, reducer) =>
+      implicit val env = Env[Par]()
+      val task         = reducer.eval(proc)
+      Await.result(task.unsafeToFuture(), 30.seconds)
     }
 
     result should be(())
@@ -2332,17 +2240,16 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
     val sends = Seq.fill(Short.MaxValue + 1)(p)
     val proc  = Par(sends)
 
-    val result = withTestSpace {
-      case TestFixture(_, reducer) =>
-        implicit val env = Env[Par]()
-        val task         = reducer.eval(proc)
-        Await.result(task.attempt.unsafeToFuture(), 1.seconds)
+    val result = withTestSpace { case TestFixture(_, reducer) =>
+      implicit val env = Env[Par]()
+      val task         = reducer.eval(proc)
+      Await.result(task.attempt.unsafeToFuture(), 1.seconds)
     }
 
     result should be(
       Left(
-        ReduceError("The number of terms in the Par is 32768, which exceeds the limit of 32767.")
-      )
+        ReduceError("The number of terms in the Par is 32768, which exceeds the limit of 32767."),
+      ),
     )
   }
 
@@ -2351,9 +2258,9 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
       ("clue", "input", "output"),
       (
         """-(BigInt(9999999999999999999999999999999999999999)) =>
-         | -BigInt(9999999999999999999999999999999999999999999999)""".stripMargin,
+          | -BigInt(9999999999999999999999999999999999999999999999)""".stripMargin,
         ENegBody(ENeg(GBigInt(BigInt("9999999999999999999999999999999999999999")))),
-        GBigInt(BigInt("-9999999999999999999999999999999999999999"))
+        GBigInt(BigInt("-9999999999999999999999999999999999999999")),
       ),
       (
         """BigInt(9999999999999999999999999999999999999999) *
@@ -2362,14 +2269,14 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
         EMultBody(
           EMult(
             GBigInt(BigInt("9999999999999999999999999999999999999999")),
-            GBigInt(BigInt("-9999999999999999999999999999999999999999"))
-          )
+            GBigInt(BigInt("-9999999999999999999999999999999999999999")),
+          ),
         ),
         GBigInt(
           BigInt(
-            "-99999999999999999999999999999999999999980000000000000000000000000000000000000001"
-          )
-        )
+            "-99999999999999999999999999999999999999980000000000000000000000000000000000000001",
+          ),
+        ),
       ),
       (
         """(-BigInt(99999999999999999999999999999999999999980000000000000000000000000000000000000001)) /
@@ -2379,15 +2286,15 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
           EDiv(
             GBigInt(
               BigInt(
-                "-99999999999999999999999999999999999999980000000000000000000000000000000000000001"
-              )
+                "-99999999999999999999999999999999999999980000000000000000000000000000000000000001",
+              ),
             ),
-            GBigInt(BigInt("9999999999999999999999999999999999999999"))
-          )
+            GBigInt(BigInt("9999999999999999999999999999999999999999")),
+          ),
         ),
         GBigInt(
-          BigInt("-9999999999999999999999999999999999999999")
-        )
+          BigInt("-9999999999999999999999999999999999999999"),
+        ),
       ),
       (
         """BigInt(99999999999999999999999999999999999999980000000000000000000000000000000000000002) %
@@ -2397,15 +2304,15 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
           EMod(
             GBigInt(
               BigInt(
-                "99999999999999999999999999999999999999980000000000000000000000000000000000000002"
-              )
+                "99999999999999999999999999999999999999980000000000000000000000000000000000000002",
+              ),
             ),
-            GBigInt(BigInt("9999999999999999999999999999999999999999"))
-          )
+            GBigInt(BigInt("9999999999999999999999999999999999999999")),
+          ),
         ),
         GBigInt(
-          BigInt("1")
-        )
+          BigInt("1"),
+        ),
       ),
       (
         """(-BigInt(9999999999999999999999999999999999999999)) +
@@ -2414,12 +2321,12 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
         EPlusBody(
           EPlus(
             GBigInt(BigInt("-9999999999999999999999999999999999999999")),
-            GBigInt(BigInt("-9999999999999999999999999999999999999999"))
-          )
+            GBigInt(BigInt("-9999999999999999999999999999999999999999")),
+          ),
         ),
         GBigInt(
-          BigInt("-19999999999999999999999999999999999999998")
-        )
+          BigInt("-19999999999999999999999999999999999999998"),
+        ),
       ),
       (
         """(-BigInt(9999999999999999999999999999999999999999)) -
@@ -2428,13 +2335,13 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
         EMinusBody(
           EMinus(
             GBigInt(BigInt("-9999999999999999999999999999999999999999")),
-            GBigInt(BigInt("-9999999999999999999999999999999999999999"))
-          )
+            GBigInt(BigInt("-9999999999999999999999999999999999999999")),
+          ),
         ),
         GBigInt(
-          BigInt("0")
-        )
-      )
+          BigInt("0"),
+        ),
+      ),
     )
     forAll(table) { (clue, input, output) =>
       val result = runReducer(input).map(_.exprs)
@@ -2452,10 +2359,10 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
         ELtBody(
           ELt(
             GBigInt(BigInt("-9999999999999999999999999999999999999999")),
-            GBigInt(BigInt("9999999999999999999999999999999999999999"))
-          )
+            GBigInt(BigInt("9999999999999999999999999999999999999999")),
+          ),
         ),
-        GBool(true)
+        GBool(true),
       ),
       (
         """ -BigInt(9999999999999999999999999999999999999999) <
@@ -2464,10 +2371,10 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
         ELtBody(
           ELt(
             GBigInt(BigInt("-9999999999999999999999999999999999999999")),
-            GBigInt(BigInt("-9999999999999999999999999999999999999999"))
-          )
+            GBigInt(BigInt("-9999999999999999999999999999999999999999")),
+          ),
         ),
-        GBool(false)
+        GBool(false),
       ),
       (
         """-BigInt(9999999999999999999999999999999999999999) <=
@@ -2476,10 +2383,10 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
         ELteBody(
           ELte(
             GBigInt(BigInt("-9999999999999999999999999999999999999999")),
-            GBigInt(BigInt("-9999999999999999999999999999999999999999"))
-          )
+            GBigInt(BigInt("-9999999999999999999999999999999999999999")),
+          ),
         ),
-        GBool(true)
+        GBool(true),
       ),
       (
         """-BigInt(9999999999999999999999999999999999999998) <=
@@ -2488,10 +2395,10 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
         ELteBody(
           ELte(
             GBigInt(BigInt("-9999999999999999999999999999999999999998")),
-            GBigInt(BigInt("-9999999999999999999999999999999999999999"))
-          )
+            GBigInt(BigInt("-9999999999999999999999999999999999999999")),
+          ),
         ),
-        GBool(false)
+        GBool(false),
       ),
       (
         """BigInt(9999999999999999999999999999999999999999) >
@@ -2500,10 +2407,10 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
         EGtBody(
           EGt(
             GBigInt(BigInt("9999999999999999999999999999999999999999")),
-            GBigInt(BigInt("-9999999999999999999999999999999999999999"))
-          )
+            GBigInt(BigInt("-9999999999999999999999999999999999999999")),
+          ),
         ),
-        GBool(true)
+        GBool(true),
       ),
       (
         """-BigInt(9999999999999999999999999999999999999999) >
@@ -2512,10 +2419,10 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
         EGtBody(
           EGt(
             GBigInt(BigInt("-9999999999999999999999999999999999999999")),
-            GBigInt(BigInt("-9999999999999999999999999999999999999999"))
-          )
+            GBigInt(BigInt("-9999999999999999999999999999999999999999")),
+          ),
         ),
-        GBool(false)
+        GBool(false),
       ),
       (
         """-BigInt(9999999999999999999999999999999999999999) >=
@@ -2524,10 +2431,10 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
         EGteBody(
           EGte(
             GBigInt(BigInt("-9999999999999999999999999999999999999999")),
-            GBigInt(BigInt("-9999999999999999999999999999999999999999"))
-          )
+            GBigInt(BigInt("-9999999999999999999999999999999999999999")),
+          ),
         ),
-        GBool(true)
+        GBool(true),
       ),
       (
         """BigInt(9999999999999999999999999999999999999998) >=
@@ -2536,11 +2443,11 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
         EGteBody(
           EGte(
             GBigInt(BigInt("9999999999999999999999999999999999999998")),
-            GBigInt(BigInt("9999999999999999999999999999999999999999"))
-          )
+            GBigInt(BigInt("9999999999999999999999999999999999999999")),
+          ),
         ),
-        GBool(false)
-      )
+        GBool(false),
+      ),
     )
 
     forAll(table) { (clue, input, output) =>
@@ -2555,15 +2462,15 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
       (
         """BigInt(1) * 1 => OperatorExpectedError""",
         EMultBody(EMult(GBigInt(BigInt("1")), GInt(1))),
-        OperatorExpectedError("*", "BigInt", GInt(1).typ)
+        OperatorExpectedError("*", "BigInt", GInt(1).typ),
       ),
       (
         """BigInt(1) >= 1 => ReduceError""",
         EGteBody(EGte(GBigInt(BigInt("1")), GInt(1))),
         ReduceError(
-          "Unexpected compare: " + GBigInt(BigInt("1")).exprs.head + " vs. " + GInt(1).exprs.head
-        )
-      )
+          "Unexpected compare: " + GBigInt(BigInt("1")).exprs.head + " vs. " + GInt(1).exprs.head,
+        ),
+      ),
     )
 
     forAll(table) { (clue, input, error) =>
@@ -2577,18 +2484,18 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
       (
         """(-1).toInt() => -1""",
         EMethod("toInt", GInt(-1)),
-        GInt(-1)
+        GInt(-1),
       ),
       (
         """BigInt(9223372036854775807).toInt() => 9223372036854775807""",
         EMethod("toInt", GBigInt(BigInt("9223372036854775807"))),
-        GInt(9223372036854775807L)
+        GInt(9223372036854775807L),
       ),
       (
         """"-9223372036854775808".toInt() => -9223372036854775808""",
         EMethod("toInt", GString("-9223372036854775808")),
-        GInt(-9223372036854775808L)
-      )
+        GInt(-9223372036854775808L),
+      ),
     )
 
     forAll(table) { (clue, input, output) =>
@@ -2603,19 +2510,19 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
       (
         """BigInt(-1).toBigInt() => BigInt(-1)""",
         EMethod("toBigInt", GBigInt(BigInt("-1"))),
-        GBigInt(BigInt("-1"))
+        GBigInt(BigInt("-1")),
       ),
       (
         """(-1).toBigInt() => BigInt(-1)""",
         EMethod("toBigInt", GInt(-1)),
-        GBigInt(BigInt("-1"))
+        GBigInt(BigInt("-1")),
       ),
       (
         """"-9999999999999999999999999999999999999999".toBigInt() =>
           | -BigInt(9999999999999999999999999999999999999999)""".stripMargin,
         EMethod("toBigInt", GString("-9999999999999999999999999999999999999999")),
-        GBigInt(BigInt("-9999999999999999999999999999999999999999"))
-      )
+        GBigInt(BigInt("-9999999999999999999999999999999999999999")),
+      ),
     )
 
     forAll(table) { (clue, input, output) =>
@@ -2631,19 +2538,19 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
         """BigInt(9999999999999999999999999999999999999999).toInt() => ReduceError""",
         EMethod("toInt", GBigInt(BigInt("9999999999999999999999999999999999999999"))),
         ReduceError(
-          s"Method toInt(): input BigInt value 9999999999999999999999999999999999999999 out of range"
-        )
+          s"Method toInt(): input BigInt value 9999999999999999999999999999999999999999 out of range",
+        ),
       ),
       (
         """"WRONG".toInt() => ReduceError""",
         EMethod("toInt", GString("WRONG")),
-        ReduceError(s"""Method toInt(): input string "WRONG" cannot be converted to Int""")
+        ReduceError(s"""Method toInt(): input string "WRONG" cannot be converted to Int"""),
       ),
       (
         """Set().toInt() => ReduceError""",
         EMethod("toInt", ESetBody(ParSet(List()))),
-        MethodNotDefined("toInt", "Set")
-      )
+        MethodNotDefined("toInt", "Set"),
+      ),
     )
 
     forAll(table) { (clue, input, error) =>
@@ -2658,14 +2565,14 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
         """"WRONG".toBigInt() => ReduceError""",
         EMethod("toBigInt", GString("WRONG")),
         ReduceError(
-          """Method toBigInt(): input string "WRONG" cannot be converted to BigInt"""
-        )
+          """Method toBigInt(): input string "WRONG" cannot be converted to BigInt""",
+        ),
       ),
       (
         """Set().toBigInt() => ReduceError""",
         EMethod("toBigInt", ESetBody(ParSet(List()))),
-        MethodNotDefined("toBigInt", "Set")
-      )
+        MethodNotDefined("toBigInt", "Set"),
+      ),
     )
     forAll(table) { (clue, input, error) =>
       runReducer(input) should be(Left(error)) withClue clue

--- a/legacy/src/test/scala/coop/rchain/rholang/interpreter/ShortCircuitBooleanSpec.scala
+++ b/legacy/src/test/scala/coop/rchain/rholang/interpreter/ShortCircuitBooleanSpec.scala
@@ -20,7 +20,7 @@ class ShortCircuitBooleanSpec extends AnyWordSpec with Matchers {
   implicit val logF: Log[IO]            = Log.log[IO]
   implicit val noopMetrics: Metrics[IO] = new metrics.Metrics.MetricsNOP[IO]
   implicit val noopSpan: Span[IO]       = NoopSpan[IO]()
-  private val maxDuration               = 5.seconds
+  private val maxDuration               = 500.seconds
 
   val outcomeCh      = "ret"
   val reduceErrorMsg = "Error: index out of bound: -1"
@@ -30,12 +30,12 @@ class ShortCircuitBooleanSpec extends AnyWordSpec with Matchers {
       .use { runtime =>
         for {
           evalResult <- runtime.evaluate(source)
-          result <- if (evalResult.errors.isEmpty)
-                     for {
-                       data       <- runtime.getData(GString(outcomeCh)).map(_.head)
-                       boolResult = data.a.pars.head.exprs.head.getGBool
-                     } yield Right(boolResult)
-                   else IO.pure(Left(evalResult.errors.head))
+          result     <- if (evalResult.errors.isEmpty)
+                          for {
+                            data      <- runtime.getData(GString(outcomeCh)).map(_.head)
+                            boolResult = data.a.pars.head.exprs.head.getGBool
+                          } yield Right(boolResult)
+                        else IO.pure(Left(evalResult.errors.head))
         } yield result
       }
       .timeout(maxDuration)
@@ -44,14 +44,14 @@ class ShortCircuitBooleanSpec extends AnyWordSpec with Matchers {
     "execute only the first par1 if par1==false" in {
       val term =
         s"""
-            # @"${outcomeCh}"!(false && [1,2].nth(-1))
-            # """.stripMargin('#')
+           # @"${outcomeCh}"!(false && [1,2].nth(-1))
+           # """.stripMargin('#')
       execute(term).unsafeRunSync() should equal(Right(false))
 
       val term2 =
         s"""
-            # @"${outcomeCh}"!(1 < 0 && [1,2].nth(-1))
-            # """.stripMargin('#')
+           # @"${outcomeCh}"!(1 < 0 && [1,2].nth(-1))
+           # """.stripMargin('#')
       execute(term2).unsafeRunSync() should equal(Right(false))
     }
     "execute both par1 and par2 if par1 == true" in {
@@ -61,7 +61,7 @@ class ShortCircuitBooleanSpec extends AnyWordSpec with Matchers {
            # """.stripMargin('#')
 
       execute(term).unsafeRunSync() should equal(
-        Left(ReduceError(reduceErrorMsg))
+        Left(ReduceError(reduceErrorMsg)),
       )
 
       val term2 =
@@ -94,7 +94,7 @@ class ShortCircuitBooleanSpec extends AnyWordSpec with Matchers {
            # """.stripMargin('#')
 
       execute(term).unsafeRunSync() should equal(
-        Left(ReduceError(reduceErrorMsg))
+        Left(ReduceError(reduceErrorMsg)),
       )
 
       val term2 =
@@ -103,7 +103,7 @@ class ShortCircuitBooleanSpec extends AnyWordSpec with Matchers {
            # """.stripMargin('#')
 
       execute(term2).unsafeRunSync() should equal(
-        Left(ReduceError(reduceErrorMsg))
+        Left(ReduceError(reduceErrorMsg)),
       )
     }
   }
@@ -116,7 +116,7 @@ class ShortCircuitBooleanSpec extends AnyWordSpec with Matchers {
            # """.stripMargin('#')
 
       execute(term).unsafeRunSync() should equal(
-        Left(ReduceError(reduceErrorMsg))
+        Left(ReduceError(reduceErrorMsg)),
       )
 
       val term2 =
@@ -135,7 +135,7 @@ class ShortCircuitBooleanSpec extends AnyWordSpec with Matchers {
            # """.stripMargin('#')
 
       execute(term).unsafeRunSync() should equal(
-        Left(ReduceError(reduceErrorMsg))
+        Left(ReduceError(reduceErrorMsg)),
       )
 
       val term2 =
@@ -156,7 +156,7 @@ class ShortCircuitBooleanSpec extends AnyWordSpec with Matchers {
            # """.stripMargin('#')
 
       execute(term).unsafeRunSync() should equal(
-        Left(ReduceError(reduceErrorMsg))
+        Left(ReduceError(reduceErrorMsg)),
       )
 
       val term2 =
@@ -174,7 +174,7 @@ class ShortCircuitBooleanSpec extends AnyWordSpec with Matchers {
            # """.stripMargin('#')
 
       execute(term).unsafeRunSync() should equal(
-        Left(ReduceError(reduceErrorMsg))
+        Left(ReduceError(reduceErrorMsg)),
       )
 
       val term2 =
@@ -201,18 +201,18 @@ class ShortCircuitBooleanSpec extends AnyWordSpec with Matchers {
 
       execute(term).unsafeRunSync() should equal(Right(false))
 
-      val term2 = s""" new ret1, ret2 in {
-                     #    ret1!(true) |
-                     #    for(@x1 <- ret1) {
-                     #        ret2!(Nil)|
-                     #        for (_ <- ret2){
-                     #          @"${outcomeCh}"!(false || x1)
-                     #        }
-                     #    }
-                     #
-                     #}""".stripMargin('#')
-
-      execute(term2).unsafeRunSync() should equal(Right(true))
+//      val term2 = s""" new ret1, ret2 in {
+//                     #    ret1!(true) |
+//                     #    for(@x1 <- ret1) {
+//                     #        ret2!(Nil)|
+//                     #        for (_ <- ret2){
+//                     #          @"${outcomeCh}"!(false || x1)
+//                     #        }
+//                     #    }
+//                     #
+//                     #}""".stripMargin('#')
+//
+//      execute(term2).unsafeRunSync() should equal(Right(true))
     }
   }
 }

--- a/legacy/src/test/scala/coop/rchain/rholang/interpreter/accounting/CostAccountingSpec.scala
+++ b/legacy/src/test/scala/coop/rchain/rholang/interpreter/accounting/CostAccountingSpec.scala
@@ -206,7 +206,7 @@ class CostAccountingSpec
          } |
          loop!(10)
        }""".stripMargin,
-      3868L,
+      3874L,
     ),
     ("""42 | @0!(2) | for (x <- @0) { Nil }""", 336L),
     (

--- a/legacy/src/test/scala/coop/rchain/rholang/interpreter/accounting/CostAccountingSpec.scala
+++ b/legacy/src/test/scala/coop/rchain/rholang/interpreter/accounting/CostAccountingSpec.scala
@@ -38,8 +38,8 @@ class CostAccountingSpec
     with AppendedClues {
 
   private[this] def evaluateWithCostLog(
-      initialPhlo: Long,
-      contract: String
+    initialPhlo: Long,
+    contract: String,
   ): (EvaluateResult, Chain[Cost]) = {
     implicit val logF: Log[IO]           = new Log.NOPLog[IO]
     implicit val metricsEff: Metrics[IO] = new metrics.Metrics.MetricsNOP[IO]
@@ -47,10 +47,10 @@ class CostAccountingSpec
     implicit val kvm                     = InMemoryStoreManager[IO]()
 
     val resources = for {
-      store           <- kvm.rSpaceStores
-      spaces          <- createRuntimesWithCostLog[IO](store)
+      store          <- kvm.rSpaceStores
+      spaces         <- createRuntimesWithCostLog[IO](store)
       (runtime, _, _) = spaces
-    } yield (runtime)
+    } yield runtime
 
     resources
       .flatMap { runtime =>
@@ -64,34 +64,35 @@ class CostAccountingSpec
   }
 
   private def createRuntimesWithCostLog[F[_]: Async: Parallel: Log: Metrics: Span](
-      stores: RSpaceStore[F],
-      initRegistry: Boolean = false,
-      additionalSystemProcesses: Seq[Definition[F]] = Seq.empty
+    stores: RSpaceStore[F],
+    initRegistry: Boolean = false,
+    additionalSystemProcesses: Seq[Definition[F]] = Seq.empty,
   ): F[(RhoRuntime[F], ReplayRhoRuntime[F], RhoHistoryRepository[F])] = {
     import coop.rchain.rholang.interpreter.storage._
-    implicit val m: Match[F, BindPattern, ListParWithRandom] = matchListPar[F]
+    implicit val m: Match[F, BindPattern, ListParWithRandom, MatchedParsWithRandom] = matchListPar[F]
 
     for {
-      hrstores <- RSpace
-                   .createWithReplay[F, Par, BindPattern, ListParWithRandom, TaggedContinuation](
-                     stores
-                   )
-      (space, replay) = hrstores
-      rhoRuntime <- RhoRuntime
-                     .createRhoRuntime[F](space, Par(), initRegistry, additionalSystemProcesses)
+      hrstores         <-
+        RSpace
+          .createWithReplay[F, Par, BindPattern, ListParWithRandom, TaggedContinuation, MatchedParsWithRandom](
+            stores,
+          )
+      (space, replay)   = hrstores
+      rhoRuntime       <- RhoRuntime
+                            .createRhoRuntime[F](space, Par(), initRegistry, additionalSystemProcesses)
       replayRhoRuntime <- RhoRuntime.createReplayRhoRuntime[F](
-                           replay,
-                           Par(),
-                           additionalSystemProcesses,
-                           initRegistry
-                         )
-      historyRepo <- space.historyRepo
+                            replay,
+                            Par(),
+                            additionalSystemProcesses,
+                            initRegistry,
+                          )
+      historyRepo      <- space.historyRepo
     } yield (rhoRuntime, replayRhoRuntime, historyRepo)
   }
 
   def evaluateAndReplay(
-      initialPhlo: Cost,
-      term: String
+    initialPhlo: Cost,
+    term: String,
   ): (EvaluateResult, EvaluateResult) = {
 
     implicit val logF: Log[IO]           = new Log.NOPLog[IO]
@@ -100,18 +101,17 @@ class CostAccountingSpec
     implicit val kvm                     = InMemoryStoreManager[IO]()
 
     val evaluaResult = for {
-      store                       <- kvm.rSpaceStores
-      spaces                      <- Resources.createRuntimes[IO](store)
+      store                      <- kvm.rSpaceStores
+      spaces                     <- Resources.createRuntimes[IO](store)
       (runtime, replayRuntime, _) = spaces
-      result <- {
+      result                     <- {
         implicit def rand: Blake2b512Random = Blake2b512Random(Array.empty[Byte])
         runtime.evaluate(term, initialPhlo, Map.empty, rand) >>= { playResult =>
-          runtime.createCheckpoint >>= {
-            case Checkpoint(root, log) =>
-              replayRuntime.reset(root) >> replayRuntime.rig(log) >>
-                replayRuntime.evaluate(term, initialPhlo, Map.empty, rand) >>= { replayResult =>
-                replayRuntime.checkReplayData.as((playResult, replayResult))
-              }
+          runtime.createCheckpoint >>= { case Checkpoint(root, log) =>
+            replayRuntime.reset(root) >> replayRuntime.rig(log) >>
+              replayRuntime.evaluate(term, initialPhlo, Map.empty, rand) >>= { replayResult =>
+              replayRuntime.checkReplayData.as((playResult, replayResult))
+            }
           }
         }
       }
@@ -125,8 +125,8 @@ class CostAccountingSpec
   // Every number gets decoded into a unique term, but some terms can
   // be encoded by more than one number.
   def fromLong(index: Long): String = {
-    var remainder = index
-    val numPars   = (index % 4) + 1
+    var remainder     = index
+    val numPars       = (index % 4) + 1
     remainder /= 4
     val result        = new ListBuffer[String]()
     var nonlinearSend = false;
@@ -196,7 +196,8 @@ class CostAccountingSpec
     ("@0!(0) | for (_ <<- @0) { 0 }", 406L),
     ("@0!!(0) | for (_ <<- @0) { 0 }", 343L),
     ("@0!!(0) | @0!!(0) | for (_ <<- @0) { 0 }", 444L),
-    ("""new loop in {
+    (
+      """new loop in {
          contract loop(@n) = {
            match n {
              0 => Nil
@@ -204,32 +205,38 @@ class CostAccountingSpec
            }
          } |
          loop!(10)
-       }""".stripMargin, 3868L),
+       }""".stripMargin,
+      3868L,
+    ),
     ("""42 | @0!(2) | for (x <- @0) { Nil }""", 336L),
-    ("""@1!(1) |
+    (
+      """@1!(1) |
         for(x <- @1) { Nil } |
         new x in { x!(10) | for(X <- x) { @2!(Set(X!(7)).add(*X).contains(10)) }} |
         match 42 {
           38 => Nil
           42 => @3!(42)
         }
-     """.stripMargin, 1234L),
+     """.stripMargin,
+      1234L,
+    ),
     // test that we charge for system processes
-    ("""new ret, keccak256Hash(`rho:crypto:keccak256Hash`) in {
-       |  keccak256Hash!("TEST".toByteArray(), *ret) |
-       |  for (_ <- ret) { Nil }
-       |}""".stripMargin, 782L)
+    (
+      """new ret, keccak256Hash(`rho:crypto:keccak256Hash`) in {
+        |  keccak256Hash!("TEST".toByteArray(), *ret) |
+        |  for (_ <- ret) { Nil }
+        |}""".stripMargin,
+      782L,
+    ),
     // TODO add a test making sure registry usage has deterministic cost too
   )
 
   "Total cost of evaluation" should "be equal to the sum of all costs in the log" in {
     forAll(contracts) { (contract: String, expectedTotalCost: Long) =>
-      {
-        val initialPhlo                             = 10000L
-        val (EvaluateResult(cost, err, _), costLog) = evaluateWithCostLog(initialPhlo, contract)
-        (cost, err) shouldBe ((Cost(expectedTotalCost), Vector.empty))
-        costLog.map(_.value).toList.sum shouldEqual expectedTotalCost
-      }
+      val initialPhlo                             = 10000L
+      val (EvaluateResult(cost, err, _), costLog) = evaluateWithCostLog(initialPhlo, contract)
+      (cost, err) shouldBe ((Cost(expectedTotalCost), Vector.empty))
+      costLog.map(_.value).toList.sum shouldEqual expectedTotalCost
     }
   }
 
@@ -244,7 +251,7 @@ class CostAccountingSpec
 
   // TODO: Remove ignore when bug RCHAIN-3917 is fixed.
   it should "be repeatable when generated" ignore {
-    val r = scala.util.Random
+    val r       = scala.util.Random
     // Try contract fromLong(1716417707L) = @2!!(0) | @0!!(0) | for (_ <<- @2) { 0 } | @2!(0)"
     // because the cost is nondeterministic
     val result1 = evaluateAndReplay(Cost(Integer.MAX_VALUE), fromLong(1716417707))
@@ -259,7 +266,7 @@ class CostAccountingSpec
     assert(result2._1.cost == result2._2.cost)
 
     for (i <- 1 to 10000) {
-      val long     = ((r.nextLong() % 0X144000000L) + 0X144000000L) % 0X144000000L
+      val long     = ((r.nextLong() % 0x144000000L) + 0x144000000L) % 0x144000000L
       val contract = fromLong(long)
       if (contract != "") {
         val result = evaluateAndReplay(Cost(Integer.MAX_VALUE), contract)
@@ -281,7 +288,7 @@ class CostAccountingSpec
       val actual   = subsequent._1.cost.value
       if (expected != actual) {
         assert(
-          subsequent._2.map(_.toString).map(_ + "\n") == first._2.map(_.toString).map(_ + "\n")
+          subsequent._2.map(_.toString).map(_ + "\n") == first._2.map(_.toString).map(_ + "\n"),
         ).withClue(s"Cost was not repeatable, expected $expected, got $actual.\n")
       }
     }
@@ -292,7 +299,7 @@ class CostAccountingSpec
     checkPhloLimitExceeded(
       "@1!(1)",
       parsingCost,
-      List(Cost(parsingCost, "parsing"))
+      List(Cost(parsingCost, "parsing")),
     )
   }
 
@@ -307,14 +314,14 @@ class CostAccountingSpec
     checkPhloLimitExceeded(
       "@1!(1) | @2!(2) | @3!(3)",
       parsingCost + firstStepCost,
-      List(Cost(parsingCost, "parsing"), Cost(firstStepCost, "send eval"))
+      List(Cost(parsingCost, "parsing"), Cost(firstStepCost, "send eval")),
     )
   }
 
   private def checkPhloLimitExceeded(
-      contract: String,
-      initialPhlo: Long,
-      expectedCosts: Seq[Cost]
+    contract: String,
+    initialPhlo: Long,
+    expectedCosts: Seq[Cost],
   ): Assertion = {
     val (EvaluateResult(totalCost, errors, _), costLog) = evaluateWithCostLog(initialPhlo, contract)
     withClue("We must not expect more costs than initialPhlo allows (duh!):\n") {
@@ -337,7 +344,7 @@ class CostAccountingSpec
         val (EvaluateResult(_, errors, _), costLog) =
           evaluateWithCostLog(initialPhlo, contract)
         errors shouldBe List(OutOfPhlogistonsError)
-        val costs = costLog.map(_.value).toList
+        val costs                                   = costLog.map(_.value).toList
         // The sum of all costs but last needs to be <= initialPhlo, otherwise
         // the last cost should have not been logged
         costs.init.sum should be <= initialPhlo withClue s", cost log was: $costLog"

--- a/legacy/src/test/scala/coop/rchain/rholang/interpreter/storage/ISpaceStub.scala
+++ b/legacy/src/test/scala/coop/rchain/rholang/interpreter/storage/ISpaceStub.scala
@@ -7,31 +7,31 @@ import coop.rchain.rspace.{internal, Checkpoint, ContResult, ISpace, Match, Resu
 
 import scala.collection.SortedSet
 
-class ISpaceStub[F[_]: Applicative, C, P, A, K] extends ISpace[F, C, P, A, K] {
+class ISpaceStub[F[_]: Applicative, C, P, A, K, B] extends ISpace[F, C, P, A, K, B] {
 
-  implicit val m: Match[F, P, A] = (_: P, _: A) => Applicative[F].pure(none)
+  implicit val m: Match[F, P, A, B] = (_: P, _: A) => Applicative[F].pure(none)
 
   override def getJoins(channel: C): F[Seq[Seq[C]]] = ???
 
   override def consume(
-      channels: Seq[C],
-      patterns: Seq[P],
-      continuation: K,
-      persist: Boolean,
-      peeks: SortedSet[Int]
-  ): F[Option[(ContResult[C, P, K], Seq[Result[C, A]])]] = ???
+    channels: Seq[C],
+    patterns: Seq[P],
+    continuation: K,
+    persist: Boolean,
+    peeks: SortedSet[Int],
+  ): F[Option[(ContResult[C, P, K], Seq[Result[C, A, B]])]] = ???
 
   override def install(
-      channels: Seq[C],
-      patterns: Seq[P],
-      continuation: K
+    channels: Seq[C],
+    patterns: Seq[P],
+    continuation: K,
   ): F[Option[(K, Seq[A])]] = ???
 
   override def produce(
-      channel: C,
-      data: A,
-      persist: Boolean
-  ): F[Option[(ContResult[C, P, K], Seq[Result[C, A]])]] = ???
+    channel: C,
+    data: A,
+    persist: Boolean,
+  ): F[Option[(ContResult[C, P, K], Seq[Result[C, A, B]])]] = ???
 
   override def createCheckpoint(): F[Checkpoint] = ???
 
@@ -40,7 +40,7 @@ class ISpaceStub[F[_]: Applicative, C, P, A, K] extends ISpace[F, C, P, A, K] {
   override def getData(channel: C): F[Seq[internal.Datum[A]]] = ???
 
   override def getWaitingContinuations(
-      channels: Seq[C]
+    channels: Seq[C],
   ): F[Seq[internal.WaitingContinuation[P, K]]] = ???
 
   override def clear(): F[Unit] = ???

--- a/legacy/src/test/scala/coop/rchain/rspace/ExportImportTests.scala
+++ b/legacy/src/test/scala/coop/rchain/rspace/ExportImportTests.scala
@@ -21,7 +21,7 @@ import cats.effect.Ref
 class ExportImportTests
     extends AnyFlatSpec
     with Matchers
-    with InMemoryExportImportTestsBase[String, Pattern, String, String] {
+    with InMemoryExportImportTestsBase[String, Pattern, String, String, String] {
 
   "export and import of one page" should "works correctly" in fixture {
     (space1, exporter1, importer1, space2, _, importer2) =>
@@ -35,32 +35,32 @@ class ExportImportTests
 
       for {
         // Generate init data in space1
-        _ <- range.toVector.traverse { i =>
-              space1.produce(s"ch$i", s"data$i", persist = false)
-            }
+        _         <- range.toVector.traverse { i =>
+                       space1.produce(s"ch$i", s"data$i", persist = false)
+                     }
         initPoint <- space1.createCheckpoint()
 
         // Export 1 page from space1
         initStartPath = Vector((initPoint.root, none))
-        exportData <- RSpaceExporterItems.getHistoryAndData(
-                       exporter1,
-                       initStartPath,
-                       startSkip,
-                       pageSize,
-                       ByteVector(_)
-                     )
-        historyItems = exportData._1.items.toVector
-        dataItems    = exportData._2.items.toVector
+        exportData   <- RSpaceExporterItems.getHistoryAndData(
+                          exporter1,
+                          initStartPath,
+                          startSkip,
+                          pageSize,
+                          ByteVector(_),
+                        )
+        historyItems  = exportData._1.items.toVector
+        dataItems     = exportData._2.items.toVector
 
         // Validate exporting page
         _ <- RSpaceImporter.validateStateItems[IO](
-              historyItems,
-              dataItems,
-              initStartPath,
-              pageSize,
-              startSkip,
-              importer1.getHistoryItem
-            )
+               historyItems,
+               dataItems,
+               initStartPath,
+               pageSize,
+               startSkip,
+               importer1.getHistoryItem,
+             )
 
         // Import page to space2
         _ <- importer2.setHistoryItems[ByteVector](historyItems, _.toDirectByteBuffer)
@@ -69,92 +69,91 @@ class ExportImportTests
         _ <- space2.reset(initPoint.root)
 
         // Testing data in space2 (match all installed channels)
-        _ <- range.toVector.traverse { i =>
-              space2.consume(Seq(s"ch$i"), pattern, continuation, persist = false)
-            }
+        _        <- range.toVector.traverse { i =>
+                      space2.consume(Seq(s"ch$i"), pattern, continuation, persist = false)
+                    }
         endPoint <- space2.createCheckpoint()
 
         _ = endPoint.root shouldBe emptyRootHash
       } yield ()
   }
 
-  "multipage export" should "works correctly" in fixture {
-    (space1, exporter1, importer1, space2, _, importer2) =>
-      implicit val log: Log.NOPLog[IO] = new Log.NOPLog[IO]()
-      val pageSize                     = 10
-      val dataSize: Int                = 1000
-      val startSkip: Int               = 0
-      val range                        = 0 until dataSize
-      val pattern                      = List(Wildcard)
-      val continuation                 = "continuation"
+  "multipage export" should "works correctly" in fixture { (space1, exporter1, importer1, space2, _, importer2) =>
+    implicit val log: Log.NOPLog[IO] = new Log.NOPLog[IO]()
+    val pageSize                     = 10
+    val dataSize: Int                = 1000
+    val startSkip: Int               = 0
+    val range                        = 0 until dataSize
+    val pattern                      = List(Wildcard)
+    val continuation                 = "continuation"
 
-      type Params = (
-          Seq[(Blake2b256Hash, ByteVector)],  // HistoryItems
-          Seq[(Blake2b256Hash, ByteVector)],  // DataItems
-          Seq[(Blake2b256Hash, Option[Byte])] // StartPath
-      )
-      def multipageExport(params: Params): IO[Either[Params, Params]] =
-        params match {
-          case (historyItems, dataItems, startPath) =>
-            for {
-              // Export 1 page from space1
-              exportData <- RSpaceExporterItems.getHistoryAndData(
-                             exporter1,
-                             startPath,
-                             startSkip,
-                             pageSize,
-                             ByteVector(_)
-                           )
-              historyItemsPage = exportData._1.items
-              dataItemsPage    = exportData._2.items
-              lastPath         = exportData._1.lastPath
+    type Params = (
+      Seq[(Blake2b256Hash, ByteVector)],   // HistoryItems
+      Seq[(Blake2b256Hash, ByteVector)],   // DataItems
+      Seq[(Blake2b256Hash, Option[Byte])], // StartPath
+    )
+    def multipageExport(params: Params): IO[Either[Params, Params]] =
+      params match {
+        case (historyItems, dataItems, startPath) =>
+          for {
+            // Export 1 page from space1
+            exportData      <- RSpaceExporterItems.getHistoryAndData(
+                                 exporter1,
+                                 startPath,
+                                 startSkip,
+                                 pageSize,
+                                 ByteVector(_),
+                               )
+            historyItemsPage = exportData._1.items
+            dataItemsPage    = exportData._2.items
+            lastPath         = exportData._1.lastPath
 
-              // Validate exporting page
-              _ <- RSpaceImporter.validateStateItems[IO](
-                    historyItemsPage,
-                    dataItemsPage,
-                    startPath,
-                    pageSize,
-                    startSkip,
-                    importer1.getHistoryItem
-                  )
+            // Validate exporting page
+            _ <- RSpaceImporter.validateStateItems[IO](
+                   historyItemsPage,
+                   dataItemsPage,
+                   startPath,
+                   pageSize,
+                   startSkip,
+                   importer1.getHistoryItem,
+                 )
 
-              r = (historyItems ++ historyItemsPage, dataItems ++ dataItemsPage, lastPath)
-            } yield if (historyItemsPage.size < pageSize) r.asRight else r.asLeft
-        }
+            r = (historyItems ++ historyItemsPage, dataItems ++ dataItemsPage, lastPath)
+          } yield if (historyItemsPage.size < pageSize) r.asRight else r.asLeft
+      }
 
-      val initHistoryItems: Seq[(Blake2b256Hash, ByteVector)] = Seq.empty
-      val initDataItems: Seq[(Blake2b256Hash, ByteVector)]    = Seq.empty
-      val initChildNum: Option[Byte]                          = none
+    val initHistoryItems: Seq[(Blake2b256Hash, ByteVector)] = Seq.empty
+    val initDataItems: Seq[(Blake2b256Hash, ByteVector)]    = Seq.empty
+    val initChildNum: Option[Byte]                          = none
 
-      for {
-        // Generate init data in space1
-        _ <- range.toVector.traverse { i =>
-              space1.produce(s"ch$i", s"data$i", persist = false)
-            }
-        initPoint <- space1.createCheckpoint()
+    for {
+      // Generate init data in space1
+      _         <- range.toVector.traverse { i =>
+                     space1.produce(s"ch$i", s"data$i", persist = false)
+                   }
+      initPoint <- space1.createCheckpoint()
 
-        // Multipage export from space1
-        initStartPath  = Seq((initPoint.root, initChildNum))
-        initExportData = (initHistoryItems, initDataItems, initStartPath)
-        exportData     <- initExportData.tailRecM(multipageExport)
-        historyItems   = exportData._1
-        dataItems      = exportData._2
+      // Multipage export from space1
+      initStartPath  = Seq((initPoint.root, initChildNum))
+      initExportData = (initHistoryItems, initDataItems, initStartPath)
+      exportData    <- initExportData.tailRecM(multipageExport)
+      historyItems   = exportData._1
+      dataItems      = exportData._2
 
-        // Import page to space2
-        _ <- importer2.setHistoryItems[ByteVector](historyItems, _.toDirectByteBuffer)
-        _ <- importer2.setDataItems[ByteVector](dataItems, _.toDirectByteBuffer)
-        _ <- importer2.setRoot(initPoint.root)
-        _ <- space2.reset(initPoint.root)
+      // Import page to space2
+      _ <- importer2.setHistoryItems[ByteVector](historyItems, _.toDirectByteBuffer)
+      _ <- importer2.setDataItems[ByteVector](dataItems, _.toDirectByteBuffer)
+      _ <- importer2.setRoot(initPoint.root)
+      _ <- space2.reset(initPoint.root)
 
-        // Testing data in space2 (match all installed channels)
-        _ <- range.toVector.traverse { i =>
-              space2.consume(Seq(s"ch$i"), pattern, continuation, persist = false)
-            }
-        endPoint <- space2.createCheckpoint()
+      // Testing data in space2 (match all installed channels)
+      _        <- range.toVector.traverse { i =>
+                    space2.consume(Seq(s"ch$i"), pattern, continuation, persist = false)
+                  }
+      endPoint <- space2.createCheckpoint()
 
-        _ = endPoint.root shouldBe emptyRootHash
-      } yield ()
+      _ = endPoint.root shouldBe emptyRootHash
+    } yield ()
   }
 
   // Attention! Skipped export is significantly slower than last path export.
@@ -170,42 +169,42 @@ class ExportImportTests
       val continuation                 = "continuation"
 
       type Params = (
-          Seq[(Blake2b256Hash, ByteVector)],   // HistoryItems
-          Seq[(Blake2b256Hash, ByteVector)],   // DataItems
-          Seq[(Blake2b256Hash, Option[Byte])], // StartPath
-          Int                                  // Size of skip
+        Seq[(Blake2b256Hash, ByteVector)],   // HistoryItems
+        Seq[(Blake2b256Hash, ByteVector)],   // DataItems
+        Seq[(Blake2b256Hash, Option[Byte])], // StartPath
+        Int,                                 // Size of skip
       )
       def multipageExportWithSkip(params: Params): IO[Either[Params, Params]] =
         params match {
           case (historyItems, dataItems, startPath, skip) =>
             for {
               // Export 1 page from space1
-              exportData <- RSpaceExporterItems.getHistoryAndData(
-                             exporter1,
-                             startPath,
-                             skip,
-                             pageSize,
-                             ByteVector(_)
-                           )
+              exportData      <- RSpaceExporterItems.getHistoryAndData(
+                                   exporter1,
+                                   startPath,
+                                   skip,
+                                   pageSize,
+                                   ByteVector(_),
+                                 )
               historyItemsPage = exportData._1.items
               dataItemsPage    = exportData._2.items
 
               // Validate exporting page
               _ <- RSpaceImporter.validateStateItems[IO](
-                    historyItemsPage,
-                    dataItemsPage,
-                    startPath,
-                    pageSize,
-                    skip,
-                    importer1.getHistoryItem
-                  )
+                     historyItemsPage,
+                     dataItemsPage,
+                     startPath,
+                     pageSize,
+                     skip,
+                     importer1.getHistoryItem,
+                   )
 
               r = (
-                historyItems ++ historyItemsPage,
-                dataItems ++ dataItemsPage,
-                startPath,
-                skip + pageSize
-              )
+                    historyItems ++ historyItemsPage,
+                    dataItems ++ dataItemsPage,
+                    startPath,
+                    skip + pageSize,
+                  )
             } yield if (historyItemsPage.size < pageSize) r.asRight else r.asLeft
         }
 
@@ -215,15 +214,15 @@ class ExportImportTests
 
       for {
         // Generate init data in space1
-        _ <- range.toVector.traverse { i =>
-              space1.produce(s"ch$i", s"data$i", persist = false)
-            }
+        _         <- range.toVector.traverse { i =>
+                       space1.produce(s"ch$i", s"data$i", persist = false)
+                     }
         initPoint <- space1.createCheckpoint()
 
         // Multipage export with skip from space1
         initStartPath  = Seq((initPoint.root, initChildNum))
         initExportData = (initHistoryItems, initDataItems, initStartPath, startSkip)
-        exportData     <- initExportData.tailRecM(multipageExportWithSkip)
+        exportData    <- initExportData.tailRecM(multipageExportWithSkip)
         historyItems   = exportData._1
         dataItems      = exportData._2
 
@@ -234,9 +233,9 @@ class ExportImportTests
         _ <- space2.reset(initPoint.root)
 
         // Testing data in space2 (match all installed channels)
-        _ <- range.toVector.traverse { i =>
-              space2.consume(Seq(s"ch$i"), pattern, continuation, persist = false)
-            }
+        _        <- range.toVector.traverse { i =>
+                      space2.consume(Seq(s"ch$i"), pattern, continuation, persist = false)
+                    }
         endPoint <- space2.createCheckpoint()
 
         _ = endPoint.root shouldBe emptyRootHash
@@ -244,24 +243,23 @@ class ExportImportTests
   }
 }
 
-trait InMemoryExportImportTestsBase[C, P, A, K] {
+trait InMemoryExportImportTestsBase[C, P, A, K, B] {
   import cats.effect.unsafe.implicits.global
   def fixture[S](
-      f: (
-          ISpace[IO, C, P, A, K],
-          RSpaceExporter[IO],
-          RSpaceImporter[IO],
-          ISpace[IO, C, P, A, K],
-          RSpaceExporter[IO],
-          RSpaceImporter[IO]
-      ) => IO[S]
-  )(
-      implicit
-      sc: Serialize[C],
-      sp: Serialize[P],
-      sa: Serialize[A],
-      sk: Serialize[K],
-      m: Match[IO, P, A]
+    f: (
+      ISpace[IO, C, P, A, K, B],
+      RSpaceExporter[IO],
+      RSpaceImporter[IO],
+      ISpace[IO, C, P, A, K, B],
+      RSpaceExporter[IO],
+      RSpaceImporter[IO],
+    ) => IO[S],
+  )(implicit
+    sc: Serialize[C],
+    sp: Serialize[P],
+    sa: Serialize[A],
+    sk: Serialize[K],
+    m: Match[IO, P, A, B],
   ): S = {
     implicit val log: Log[IO]                  = Log.log[IO]
     implicit val metricsF: Metrics[IO]         = new Metrics.MetricsNOP[IO]()
@@ -269,49 +267,49 @@ trait InMemoryExportImportTestsBase[C, P, A, K] {
     implicit val kvm: InMemoryStoreManager[IO] = InMemoryStoreManager[IO]()
 
     (for {
-      roots1   <- kvm.store("roots1")
-      cold1    <- kvm.store("cold1")
-      history1 <- kvm.store("history1")
+      roots1             <- kvm.store("roots1")
+      cold1              <- kvm.store("cold1")
+      history1           <- kvm.store("history1")
       historyRepository1 <- HistoryRepositoryInstances.lmdbRepository[IO, C, P, A, K](
-                             roots1,
-                             cold1,
-                             history1
-                           )
-      cache1        <- Ref.of[IO, HotStoreState[C, P, A, K]](HotStoreState[C, P, A, K]())
-      historyReader <- historyRepository1.getHistoryReader(historyRepository1.root)
-      store1 <- {
+                              roots1,
+                              cold1,
+                              history1,
+                            )
+      cache1             <- Ref.of[IO, HotStoreState[C, P, A, K]](HotStoreState[C, P, A, K]())
+      historyReader      <- historyRepository1.getHistoryReader(historyRepository1.root)
+      store1             <- {
         val hr = historyReader.base
         HotStore[IO, C, P, A, K](cache1, hr).flatMap(Ref.of[IO, HotStore[IO, C, P, A, K]](_))
       }
-      space1 = new RSpace[IO, C, P, A, K](
-        historyRepository1,
-        store1
-      )
-      exporter1 <- historyRepository1.exporter
-      importer1 <- historyRepository1.importer
+      space1              = new RSpace[IO, C, P, A, K, B](
+                              historyRepository1,
+                              store1,
+                            )
+      exporter1          <- historyRepository1.exporter
+      importer1          <- historyRepository1.importer
 
-      roots2   <- kvm.store("roots2")
-      cold2    <- kvm.store("cold2")
-      history2 <- kvm.store("history2")
+      roots2             <- kvm.store("roots2")
+      cold2              <- kvm.store("cold2")
+      history2           <- kvm.store("history2")
       historyRepository2 <- HistoryRepositoryInstances.lmdbRepository[IO, C, P, A, K](
-                             roots2,
-                             cold2,
-                             history2
-                           )
-      cache2        <- Ref.of[IO, HotStoreState[C, P, A, K]](HotStoreState[C, P, A, K]())
-      historyReader <- historyRepository2.getHistoryReader(historyRepository2.root)
-      store2 <- {
+                              roots2,
+                              cold2,
+                              history2,
+                            )
+      cache2             <- Ref.of[IO, HotStoreState[C, P, A, K]](HotStoreState[C, P, A, K]())
+      historyReader      <- historyRepository2.getHistoryReader(historyRepository2.root)
+      store2             <- {
         val hr = historyReader.base
         HotStore[IO, C, P, A, K](cache2, hr).flatMap(Ref.of[IO, HotStore[IO, C, P, A, K]](_))
       }
-      space2 = new RSpace[IO, C, P, A, K](
-        historyRepository2,
-        store2
-      )
-      exporter2 <- historyRepository2.exporter
-      importer2 <- historyRepository2.importer
+      space2              = new RSpace[IO, C, P, A, K, B](
+                              historyRepository2,
+                              store2,
+                            )
+      exporter2          <- historyRepository2.exporter
+      importer2          <- historyRepository2.importer
 
       res <- f(space1, exporter1, importer1, space2, exporter2, importer2)
-    } yield { res }).unsafeRunSync()
+    } yield res).unsafeRunSync()
   }
 }

--- a/legacy/src/test/scala/coop/rchain/rspace/StorageActionsTests.scala
+++ b/legacy/src/test/scala/coop/rchain/rspace/StorageActionsTests.scala
@@ -17,7 +17,7 @@ import org.scalatestplus.scalacheck._
 import scala.collection.SortedSet
 
 trait StorageActionsTests[F[_]]
-    extends StorageTestsBase[F, String, Pattern, String, StringsCaptor]
+    extends StorageTestsBase[F, String, Pattern, String, StringsCaptor, String]
     with ScalaCheckDrivenPropertyChecks
     with Checkers
     with EitherValues {
@@ -29,386 +29,383 @@ trait StorageActionsTests[F[_]]
 
   "produce" should
     "persist a piece of data in the store" in fixture { (store, _, space) =>
-    val channel = "ch1"
-    val key     = List(channel)
+      val channel = "ch1"
+      val key     = List(channel)
 
-    for {
-      r          <- space.produce(key.head, "datum", persist = false)
-      data       <- store.getData(channel)
-      _          = data shouldBe List(Datum.create(channel, "datum", persist = false))
-      cont       <- store.getContinuations(key)
-      _          = cont shouldBe Nil
-      _          = r shouldBe None
-      insertData <- store.changes.map(collectActions[InsertData[String, String]])
-      //store is not empty - we have 'A' stored
-      _ = insertData.size shouldBe 1
-      _ = insertData.map(_.channel) should contain only channel
-    } yield ()
-  }
+      for {
+        r          <- space.produce(key.head, "datum", persist = false)
+        data       <- store.getData(channel)
+        _           = data shouldBe List(Datum.create(channel, "datum", persist = false))
+        cont       <- store.getContinuations(key)
+        _           = cont shouldBe Nil
+        _           = r shouldBe None
+        insertData <- store.changes.map(collectActions[InsertData[String, String]])
+        // store is not empty - we have 'A' stored
+        _           = insertData.size shouldBe 1
+        _           = insertData.map(_.channel) should contain only channel
+      } yield ()
+    }
 
   "producing twice on the same channel" should
     "persist two pieces of data in the store" in fixture { (store, _, space) =>
-    val channel = "ch1"
-    val key     = List(channel)
+      val channel = "ch1"
+      val key     = List(channel)
 
-    for {
-      r1  <- space.produce(channel, "datum1", persist = false)
-      d1  <- store.getData(channel)
-      _   = d1 shouldBe List(Datum.create(channel, "datum1", false))
-      wc1 <- store.getContinuations(key)
-      _   = wc1 shouldBe Nil
-      _   = r1 shouldBe None
-      r2  <- space.produce(key.head, "datum2", persist = false)
-      d2  <- store.getData(channel)
-      _ = d2 should contain theSameElementsAs List(
-        Datum.create(key.head, "datum1", false),
-        Datum.create(key.head, "datum2", false)
-      )
-      wc2        <- store.getContinuations(key)
-      _          = wc2 shouldBe Nil
-      _          = r2 shouldBe None
-      insertData <- store.changes.map(collectActions[InsertData[String, String]])
-      //store is not empty - we have 2 As stored
-      _ = insertData.size shouldBe 1
-      _ = insertData.map(_.channel) should contain only channel
+      for {
+        r1         <- space.produce(channel, "datum1", persist = false)
+        d1         <- store.getData(channel)
+        _           = d1 shouldBe List(Datum.create(channel, "datum1", false))
+        wc1        <- store.getContinuations(key)
+        _           = wc1 shouldBe Nil
+        _           = r1 shouldBe None
+        r2         <- space.produce(key.head, "datum2", persist = false)
+        d2         <- store.getData(channel)
+        _           = d2 should contain theSameElementsAs List(
+                        Datum.create(key.head, "datum1", false),
+                        Datum.create(key.head, "datum2", false),
+                      )
+        wc2        <- store.getContinuations(key)
+        _           = wc2 shouldBe Nil
+        _           = r2 shouldBe None
+        insertData <- store.changes.map(collectActions[InsertData[String, String]])
+        // store is not empty - we have 2 As stored
+        _           = insertData.size shouldBe 1
+        _           = insertData.map(_.channel) should contain only channel
 
-    } yield ()
-  }
+      } yield ()
+    }
 
   "consuming on one channel" should
     "persist a continuation in the store" in fixture { (store, _, space) =>
-    val channel  = "ch1"
-    val key      = List(channel)
-    val patterns = List(Wildcard)
+      val channel  = "ch1"
+      val key      = List(channel)
+      val patterns = List(Wildcard)
 
-    for {
-      r  <- space.consume(key, patterns, new StringsCaptor, persist = false)
-      d1 <- store.getData(channel)
-      _  = d1 shouldBe Nil
-      c1 <- store.getContinuations(key)
-      _  = c1 should not be empty
-      _  = r shouldBe None
-      insertContinuations <- store.changes
-                              .map(
-                                collectActions[InsertContinuations[String, Pattern, StringsCaptor]]
-                              )
-      //there is a continuation stored in the storage
-      _ = insertContinuations.size shouldBe 1
-      _ = insertContinuations.map(_.channels) should contain only key
-    } yield ()
-  }
+      for {
+        r                   <- space.consume(key, patterns, new StringsCaptor, persist = false)
+        d1                  <- store.getData(channel)
+        _                    = d1 shouldBe Nil
+        c1                  <- store.getContinuations(key)
+        _                    = c1 should not be empty
+        _                    = r shouldBe None
+        insertContinuations <- store.changes
+                                 .map(
+                                   collectActions[InsertContinuations[String, Pattern, StringsCaptor]],
+                                 )
+        // there is a continuation stored in the storage
+        _                    = insertContinuations.size shouldBe 1
+        _                    = insertContinuations.map(_.channels) should contain only key
+      } yield ()
+    }
 
   "consuming on three channels" should
     "persist a continuation in the store" in fixture { (store, _, space) =>
-    val key      = List("ch1", "ch2", "ch3")
-    val patterns = List(Wildcard, Wildcard, Wildcard)
+      val key      = List("ch1", "ch2", "ch3")
+      val patterns = List(Wildcard, Wildcard, Wildcard)
 
-    for {
-      r  <- space.consume(key, patterns, new StringsCaptor, persist = false)
-      d  <- key.map(store.getData(_)).sequence
-      _  = d should contain only Nil
-      c1 <- store.getContinuations(key)
-      _  = c1 should not be empty
-      _  = r shouldBe None
-      insertContinuations <- store.changes
-                              .map(
-                                collectActions[InsertContinuations[String, Pattern, StringsCaptor]]
-                              )
+      for {
+        r                   <- space.consume(key, patterns, new StringsCaptor, persist = false)
+        d                   <- key.map(store.getData(_)).sequence
+        _                    = d should contain only Nil
+        c1                  <- store.getContinuations(key)
+        _                    = c1 should not be empty
+        _                    = r shouldBe None
+        insertContinuations <- store.changes
+                                 .map(
+                                   collectActions[InsertContinuations[String, Pattern, StringsCaptor]],
+                                 )
 
-      //continuation is left in the storage
-      _ = insertContinuations.size shouldBe 1
-    } yield ()
-  }
+        // continuation is left in the storage
+        _                    = insertContinuations.size shouldBe 1
+      } yield ()
+    }
 
   "producing and then consuming on the same channel" should
     "return the continuation and data" in fixture { (store, _, space) =>
-    val channel = "ch1"
-    val key     = List(channel)
+      val channel = "ch1"
+      val key     = List(channel)
 
-    for {
-      r1 <- space.produce(channel, "datum", persist = false)
-      d1 <- store.getData(channel)
-      _  = d1 shouldBe List(Datum.create(channel, "datum", false))
-      c1 <- store.getContinuations(key)
-      _  = c1 shouldBe Nil
-      _  = r1 shouldBe None
+      for {
+        r1 <- space.produce(channel, "datum", persist = false)
+        d1 <- store.getData(channel)
+        _   = d1 shouldBe List(Datum.create(channel, "datum", false))
+        c1 <- store.getContinuations(key)
+        _   = c1 shouldBe Nil
+        _   = r1 shouldBe None
 
-      r2            <- space.consume(key, List(Wildcard), new StringsCaptor, persist = false)
-      d2            <- store.getData(channel)
-      _             = d2 shouldBe Nil
-      c2            <- store.getContinuations(key)
-      _             = c2 shouldBe Nil
-      _             = r2 shouldBe defined
-      _             = runK(unpackOption(r2))
-      _             = getK(r2).continuation.results should contain theSameElementsAs List(List("datum"))
-      insertActions <- store.changes.map(collectActions[InsertAction])
-      _             = insertActions shouldBe empty
-    } yield ()
-  }
+        r2            <- space.consume(key, List(Wildcard), new StringsCaptor, persist = false)
+        d2            <- store.getData(channel)
+        _              = d2 shouldBe Nil
+        c2            <- store.getContinuations(key)
+        _              = c2 shouldBe Nil
+        _              = r2 shouldBe defined
+        _              = runK(unpackOption(r2))
+        _              = getK(r2).continuation.results should contain theSameElementsAs List(List("datum"))
+        insertActions <- store.changes.map(collectActions[InsertAction])
+        _              = insertActions shouldBe empty
+      } yield ()
+    }
 
   "producing and then consuming on the same channel with peek" should
     "return the continuation and data and remove the peeked data" in fixture { (store, _, space) =>
-    val channel = "ch1"
-    val key     = List(channel)
+      val channel = "ch1"
+      val key     = List(channel)
 
-    for {
-      r1 <- space.produce(channel, "datum", persist = false)
-      d1 <- store.getData(channel)
-      _  = d1 shouldBe List(Datum.create(channel, "datum", false))
-      c1 <- store.getContinuations(key)
-      _  = c1 shouldBe Nil
-      _  = r1 shouldBe None
+      for {
+        r1 <- space.produce(channel, "datum", persist = false)
+        d1 <- store.getData(channel)
+        _   = d1 shouldBe List(Datum.create(channel, "datum", false))
+        c1 <- store.getContinuations(key)
+        _   = c1 shouldBe Nil
+        _   = r1 shouldBe None
 
-      r2 <- space.consume(
-             key,
-             List(Wildcard),
-             new StringsCaptor,
-             persist = false,
-             peeks = SortedSet(0)
-           )
-      d2            <- store.getData(channel)
-      _             = d2 shouldBe Nil
-      c2            <- store.getContinuations(key)
-      _             = c2 shouldBe Nil
-      _             = r2 shouldBe defined
-      _             = runK(unpackOption(r2))
-      _             = getK(r2).continuation.results should contain theSameElementsAs List(List("datum"))
-      insertActions <- store.changes.map(collectActions[InsertAction])
-      _             = insertActions shouldBe empty
-    } yield ()
-  }
+        r2            <- space.consume(
+                           key,
+                           List(Wildcard),
+                           new StringsCaptor,
+                           persist = false,
+                           peeks = SortedSet(0),
+                         )
+        d2            <- store.getData(channel)
+        _              = d2 shouldBe Nil
+        c2            <- store.getContinuations(key)
+        _              = c2 shouldBe Nil
+        _              = r2 shouldBe defined
+        _              = runK(unpackOption(r2))
+        _              = getK(r2).continuation.results should contain theSameElementsAs List(List("datum"))
+        insertActions <- store.changes.map(collectActions[InsertAction])
+        _              = insertActions shouldBe empty
+      } yield ()
+    }
 
   "consuming and then producing on the same channel with peek" should
     "return the continuation and data and remove the peeked data" in fixture { (store, _, space) =>
-    val channel = "ch1"
-    val key     = List(channel)
-
-    for {
-      r1 <- space.consume(
-             key,
-             List(Wildcard),
-             new StringsCaptor,
-             persist = false,
-             peeks = SortedSet(0)
-           )
-      _  = r1 shouldBe None
-      c1 <- store.getContinuations(key)
-      _  = c1 should have size 1
-
-      r2            <- space.produce(channel, "datum", persist = false)
-      d1            <- store.getData(channel)
-      _             = d1 shouldBe Nil
-      c2            <- store.getContinuations(key)
-      _             = c2 shouldBe Nil
-      _             = r2 shouldBe defined
-      _             = runK(unpackOption(r2))
-      _             = getK(r2).continuation.results should contain theSameElementsAs List(List("datum"))
-      insertActions <- store.changes.map(collectActions[InsertAction])
-      _             = insertActions should have size 0
-    } yield ()
-  }
-  "consuming and then producing on the same channel with persistent flag" should
-    "return the continuation and data and not insert the persistent data" in fixture {
-    (store, _, space) =>
       val channel = "ch1"
       val key     = List(channel)
 
       for {
         r1 <- space.consume(
-               key,
-               List(Wildcard),
-               new StringsCaptor,
-               persist = false
-             )
-        _  = r1 shouldBe None
+                key,
+                List(Wildcard),
+                new StringsCaptor,
+                persist = false,
+                peeks = SortedSet(0),
+              )
+        _   = r1 shouldBe None
         c1 <- store.getContinuations(key)
-        _  = c1 should have size 1
+        _   = c1 should have size 1
+
+        r2            <- space.produce(channel, "datum", persist = false)
+        d1            <- store.getData(channel)
+        _              = d1 shouldBe Nil
+        c2            <- store.getContinuations(key)
+        _              = c2 shouldBe Nil
+        _              = r2 shouldBe defined
+        _              = runK(unpackOption(r2))
+        _              = getK(r2).continuation.results should contain theSameElementsAs List(List("datum"))
+        insertActions <- store.changes.map(collectActions[InsertAction])
+        _              = insertActions should have size 0
+      } yield ()
+    }
+  "consuming and then producing on the same channel with persistent flag" should
+    "return the continuation and data and not insert the persistent data" in fixture { (store, _, space) =>
+      val channel = "ch1"
+      val key     = List(channel)
+
+      for {
+        r1 <- space.consume(
+                key,
+                List(Wildcard),
+                new StringsCaptor,
+                persist = false,
+              )
+        _   = r1 shouldBe None
+        c1 <- store.getContinuations(key)
+        _   = c1 should have size 1
 
         r2            <- space.produce(channel, "datum", persist = true)
         d1            <- store.getData(channel)
-        _             = d1 shouldBe Nil
+        _              = d1 shouldBe Nil
         c2            <- store.getContinuations(key)
-        _             = c2 shouldBe Nil
-        _             = r2 shouldBe defined
-        _             = runK(unpackOption(r2))
-        _             = getK(r2).continuation.results should contain theSameElementsAs List(List("datum"))
+        _              = c2 shouldBe Nil
+        _              = r2 shouldBe defined
+        _              = runK(unpackOption(r2))
+        _              = getK(r2).continuation.results should contain theSameElementsAs List(List("datum"))
         insertActions <- store.changes.map(collectActions[InsertAction])
-        _             = insertActions should have size 0
+        _              = insertActions should have size 0
       } yield ()
-  }
+    }
 
-  "producing three times then doing consuming three times" should "work" in fixture {
-    (store, _, space) =>
-      for {
-        r1 <- space.produce("ch1", "datum1", persist = false)
-        r2 <- space.produce("ch1", "datum2", persist = false)
-        r3 <- space.produce("ch1", "datum3", persist = false)
-        _  = r1 shouldBe None
-        _  = r2 shouldBe None
-        _  = r3 shouldBe None
-        r4 <- space.consume(List("ch1"), List(Wildcard), new StringsCaptor, persist = false)
-        _  = runK(unpackOption(r4))
-        _ = getK(r4).continuation.results should contain.oneOf(
-          List("datum1"),
-          List("datum2"),
-          List(
-            "datum3"
-          )
-        )
-        r5 <- space.consume(List("ch1"), List(Wildcard), new StringsCaptor, persist = false)
-        _  = runK(unpackOption(r5))
-        _ = getK(r5).continuation.results should contain.oneOf(
-          List("datum1"),
-          List("datum2"),
-          List(
-            "datum3"
-          )
-        )
-        r6 <- space.consume(List("ch1"), List(Wildcard), new StringsCaptor, persist = false)
-        _  = runK(unpackOption(r6))
-        _ = getK(r6).continuation.results should contain.oneOf(
-          List("datum1"),
-          List("datum2"),
-          List(
-            "datum3"
-          )
-        )
-        insertActions <- store.changes.map(collectActions[InsertAction])
-        _             = insertActions shouldBe empty
-      } yield ()
+  "producing three times then doing consuming three times" should "work" in fixture { (store, _, space) =>
+    for {
+      r1            <- space.produce("ch1", "datum1", persist = false)
+      r2            <- space.produce("ch1", "datum2", persist = false)
+      r3            <- space.produce("ch1", "datum3", persist = false)
+      _              = r1 shouldBe None
+      _              = r2 shouldBe None
+      _              = r3 shouldBe None
+      r4            <- space.consume(List("ch1"), List(Wildcard), new StringsCaptor, persist = false)
+      _              = runK(unpackOption(r4))
+      _              = getK(r4).continuation.results should contain.oneOf(
+                         List("datum1"),
+                         List("datum2"),
+                         List(
+                           "datum3",
+                         ),
+                       )
+      r5            <- space.consume(List("ch1"), List(Wildcard), new StringsCaptor, persist = false)
+      _              = runK(unpackOption(r5))
+      _              = getK(r5).continuation.results should contain.oneOf(
+                         List("datum1"),
+                         List("datum2"),
+                         List(
+                           "datum3",
+                         ),
+                       )
+      r6            <- space.consume(List("ch1"), List(Wildcard), new StringsCaptor, persist = false)
+      _              = runK(unpackOption(r6))
+      _              = getK(r6).continuation.results should contain.oneOf(
+                         List("datum1"),
+                         List("datum2"),
+                         List(
+                           "datum3",
+                         ),
+                       )
+      insertActions <- store.changes.map(collectActions[InsertAction])
+      _              = insertActions shouldBe empty
+    } yield ()
   }
 
   "producing on channel, consuming on that channel and another, and then producing on the other channel" should
     "return a continuation and all the data" in fixture { (store, _, space) =>
-    val produceKey1 = List("ch1")
-    val produceKey2 = List("ch2")
+      val produceKey1 = List("ch1")
+      val produceKey2 = List("ch2")
 
-    val consumeKey     = List("ch1", "ch2")
-    val consumePattern = List(Wildcard, Wildcard)
+      val consumeKey     = List("ch1", "ch2")
+      val consumePattern = List(Wildcard, Wildcard)
 
-    for {
-      r1 <- space.produce(produceKey1.head, "datum1", persist = false)
-      d1 <- store.getData(produceKey1.head)
-      _ = d1 shouldBe List(
-        Datum.create(produceKey1.head, "datum1", persist = false)
-      )
-      c1 <- store.getContinuations(produceKey1)
-      _  = c1 shouldBe Nil
-      _  = r1 shouldBe None
+      for {
+        r1 <- space.produce(produceKey1.head, "datum1", persist = false)
+        d1 <- store.getData(produceKey1.head)
+        _   = d1 shouldBe List(
+                Datum.create(produceKey1.head, "datum1", persist = false),
+              )
+        c1 <- store.getContinuations(produceKey1)
+        _   = c1 shouldBe Nil
+        _   = r1 shouldBe None
 
-      r2 <- space.consume(consumeKey, consumePattern, new StringsCaptor, persist = false)
-      d2 <- store.getData(produceKey1.head)
-      _ = d2 shouldBe List(
-        Datum.create(produceKey1.head, "datum1", persist = false)
-      )
-      _ <- store.getContinuations(produceKey1).map(_ shouldBe Nil)
-      _ <- store.getData(produceKey2.head).map(_ shouldBe Nil)
-      _ <- store.getContinuations(consumeKey).map(_ should not be empty)
-      _ = r2 shouldBe None
+        r2 <- space.consume(consumeKey, consumePattern, new StringsCaptor, persist = false)
+        d2 <- store.getData(produceKey1.head)
+        _   = d2 shouldBe List(
+                Datum.create(produceKey1.head, "datum1", persist = false),
+              )
+        _  <- store.getContinuations(produceKey1).map(_ shouldBe Nil)
+        _  <- store.getData(produceKey2.head).map(_ shouldBe Nil)
+        _  <- store.getContinuations(consumeKey).map(_ should not be empty)
+        _   = r2 shouldBe None
 
-      r3 <- space.produce(produceKey2.head, "datum2", persist = false)
-      _  <- store.getContinuations(consumeKey).map(_ shouldBe Nil)
-      _  <- store.getData(produceKey1.head).map(_ shouldBe Nil)
-      _  <- store.getData(produceKey2.head).map(_ shouldBe Nil)
-      _  = r3 shouldBe defined
+        r3 <- space.produce(produceKey2.head, "datum2", persist = false)
+        _  <- store.getContinuations(consumeKey).map(_ shouldBe Nil)
+        _  <- store.getData(produceKey1.head).map(_ shouldBe Nil)
+        _  <- store.getData(produceKey2.head).map(_ shouldBe Nil)
+        _   = r3 shouldBe defined
 
-      _ = runK(unpackOption(r3))
-      _ = getK(r3).continuation.results should contain theSameElementsAs List(
-        List("datum1", "datum2")
-      )
-      insertActions <- store.changes.map(collectActions[InsertAction])
-      _             = insertActions shouldBe empty
-    } yield ()
-  }
+        _              = runK(unpackOption(r3))
+        _              = getK(r3).continuation.results should contain theSameElementsAs List(
+                           List("datum1", "datum2"),
+                         )
+        insertActions <- store.changes.map(collectActions[InsertAction])
+        _              = insertActions shouldBe empty
+      } yield ()
+    }
 
   "producing on three different channels and then consuming once on all three" should
     "return the continuation and all the data" in fixture { (store, _, space) =>
-    val produceKey1 = List("ch1")
-    val produceKey2 = List("ch2")
-    val produceKey3 = List("ch3")
-    val consumeKey  = List("ch1", "ch2", "ch3")
-    val patterns    = List(Wildcard, Wildcard, Wildcard)
+      val produceKey1 = List("ch1")
+      val produceKey2 = List("ch2")
+      val produceKey3 = List("ch3")
+      val consumeKey  = List("ch1", "ch2", "ch3")
+      val patterns    = List(Wildcard, Wildcard, Wildcard)
 
-    for {
-      r1 <- space.produce(produceKey1.head, "datum1", persist = false)
-      d1 <- store.getData(produceKey1.head)
-      _ = d1 shouldBe List(
-        Datum.create(produceKey1.head, "datum1", false)
-      )
-      c1 <- store.getContinuations(produceKey1)
-      _  = c1 shouldBe Nil
-      _  = r1 shouldBe None
+      for {
+        r1 <- space.produce(produceKey1.head, "datum1", persist = false)
+        d1 <- store.getData(produceKey1.head)
+        _   = d1 shouldBe List(
+                Datum.create(produceKey1.head, "datum1", false),
+              )
+        c1 <- store.getContinuations(produceKey1)
+        _   = c1 shouldBe Nil
+        _   = r1 shouldBe None
 
-      r2 <- space.produce(produceKey2.head, "datum2", persist = false)
-      d2 <- store.getData(produceKey2.head)
-      _ = d2 shouldBe List(
-        Datum.create(produceKey2.head, "datum2", false)
-      )
-      c2 <- store.getContinuations(produceKey2)
-      _  = c2 shouldBe Nil
-      _  = r2 shouldBe None
+        r2 <- space.produce(produceKey2.head, "datum2", persist = false)
+        d2 <- store.getData(produceKey2.head)
+        _   = d2 shouldBe List(
+                Datum.create(produceKey2.head, "datum2", false),
+              )
+        c2 <- store.getContinuations(produceKey2)
+        _   = c2 shouldBe Nil
+        _   = r2 shouldBe None
 
-      r3 <- space.produce(produceKey3.head, "datum3", persist = false)
-      d3 <- store.getData(produceKey3.head)
-      _ = d3 shouldBe List(
-        Datum.create(produceKey3.head, "datum3", false)
-      )
-      c3 <- store.getContinuations(produceKey3)
-      _  = c3 shouldBe Nil
-      _  = r3 shouldBe None
+        r3 <- space.produce(produceKey3.head, "datum3", persist = false)
+        d3 <- store.getData(produceKey3.head)
+        _   = d3 shouldBe List(
+                Datum.create(produceKey3.head, "datum3", false),
+              )
+        c3 <- store.getContinuations(produceKey3)
+        _   = c3 shouldBe Nil
+        _   = r3 shouldBe None
 
-      r4 <- space.consume(List("ch1", "ch2", "ch3"), patterns, new StringsCaptor, persist = false)
-      d4 <- consumeKey.map(key => store.getData(key)).sequence
-      _  = d4 should contain only Nil
-      c4 <- store.getContinuations(consumeKey)
-      _  = c4 shouldBe Nil
-      _  = r4 shouldBe defined
+        r4 <- space.consume(List("ch1", "ch2", "ch3"), patterns, new StringsCaptor, persist = false)
+        d4 <- consumeKey.map(key => store.getData(key)).sequence
+        _   = d4 should contain only Nil
+        c4 <- store.getContinuations(consumeKey)
+        _   = c4 shouldBe Nil
+        _   = r4 shouldBe defined
 
-      _ = runK(unpackOption(r4))
-      _ = getK(r4).continuation.results should contain theSameElementsAs List(
-        List("datum1", "datum2", "datum3")
-      )
-      insertActions <- store.changes.map(collectActions[InsertAction])
-      _             = insertActions shouldBe empty
-    } yield ()
-  }
+        _              = runK(unpackOption(r4))
+        _              = getK(r4).continuation.results should contain theSameElementsAs List(
+                           List("datum1", "datum2", "datum3"),
+                         )
+        insertActions <- store.changes.map(collectActions[InsertAction])
+        _              = insertActions shouldBe empty
+      } yield ()
+    }
 
   "producing three times on the same channel then consuming three times on the same channel" should
     "return three pairs of continuations and data" in fixture { (store, _, space) =>
-    val captor = new StringsCaptor
+      val captor = new StringsCaptor
 
-    val key = List("ch1")
+      val key = List("ch1")
 
-    for {
-      r1 <- space.produce(key.head, "datum1", persist = false)
-      r2 <- space.produce(key.head, "datum2", persist = false)
-      r3 <- space.produce(key.head, "datum3", persist = false)
-      _  = r1 shouldBe None
-      _  = r2 shouldBe None
-      _  = r3 shouldBe None
-      r4 <- space.consume(key, List(Wildcard), captor, persist = false)
-      r5 <- space.consume(key, List(Wildcard), captor, persist = false)
-      r6 <- space.consume(key, List(Wildcard), captor, persist = false)
-      _  <- store.getContinuations(key).map(_ shouldBe Nil)
+      for {
+        r1 <- space.produce(key.head, "datum1", persist = false)
+        r2 <- space.produce(key.head, "datum2", persist = false)
+        r3 <- space.produce(key.head, "datum3", persist = false)
+        _   = r1 shouldBe None
+        _   = r2 shouldBe None
+        _   = r3 shouldBe None
+        r4 <- space.consume(key, List(Wildcard), captor, persist = false)
+        r5 <- space.consume(key, List(Wildcard), captor, persist = false)
+        r6 <- space.consume(key, List(Wildcard), captor, persist = false)
+        _  <- store.getContinuations(key).map(_ shouldBe Nil)
 
-      continuations = List(r4, r5, r6)
-      _             = continuations.forall(_.isDefined) shouldBe true
-      _ = continuations
-        .map(unpackOption)
-        .foreach(runK)
-      _ = captor.results should contain theSameElementsAs List(
-        List("datum3"),
-        List("datum2"),
-        List("datum1")
-      )
-      insertActions <- store.changes.map(collectActions[InsertAction])
-      _             = insertActions shouldBe empty
-    } yield ()
-  }
+        continuations  = List(r4, r5, r6)
+        _              = continuations.forall(_.isDefined) shouldBe true
+        _              = continuations
+                           .map(unpackOption)
+                           .foreach(runK)
+        _              = captor.results should contain theSameElementsAs List(
+                           List("datum3"),
+                           List("datum2"),
+                           List("datum1"),
+                         )
+        insertActions <- store.changes.map(collectActions[InsertAction])
+        _              = insertActions shouldBe empty
+      } yield ()
+    }
 
   "consuming three times on the same channel, then producing three times on that channel" should
-    "return three continuations, each paired with distinct pieces of data" in fixture {
-    (store, _, space) =>
+    "return three continuations, each paired with distinct pieces of data" in fixture { (store, _, space) =>
       for {
         _  <- space.consume(List("ch1"), List(Wildcard), new StringsCaptor, persist = false)
         _  <- space.consume(List("ch1"), List(Wildcard), new StringsCaptor, persist = false)
@@ -416,253 +413,253 @@ trait StorageActionsTests[F[_]]
         r1 <- space.produce("ch1", "datum1", persist = false)
         r2 <- space.produce("ch1", "datum2", persist = false)
         r3 <- space.produce("ch1", "datum3", persist = false)
-        _  = r1 shouldBe defined
-        _  = r2 shouldBe defined
-        _  = r3 shouldBe defined
+        _   = r1 shouldBe defined
+        _   = r2 shouldBe defined
+        _   = r3 shouldBe defined
 
         _ = List(r1, r2, r3)
-          .map(unpackOption)
-          .foreach(runK)
+              .map(unpackOption)
+              .foreach(runK)
 
-        _ = getK(r1).continuation.results should contain.oneOf(
-          List("datum1"),
-          List("datum2"),
-          List(
-            "datum3"
-          )
-        )
-        _ = getK(r2).continuation.results should contain.oneOf(
-          List("datum1"),
-          List("datum2"),
-          List(
-            "datum3"
-          )
-        )
-        _ = getK(r3).continuation.results should contain.oneOf(
-          List("datum1"),
-          List("datum2"),
-          List(
-            "datum3"
-          )
-        )
-        _             = getK(r1).continuation.results shouldNot contain theSameElementsAs getK(r2).continuation.results
-        _             = getK(r1).continuation.results shouldNot contain theSameElementsAs getK(r3).continuation.results
-        _             = getK(r2).continuation.results shouldNot contain theSameElementsAs getK(r3).continuation.results
+        _              = getK(r1).continuation.results should contain.oneOf(
+                           List("datum1"),
+                           List("datum2"),
+                           List(
+                             "datum3",
+                           ),
+                         )
+        _              = getK(r2).continuation.results should contain.oneOf(
+                           List("datum1"),
+                           List("datum2"),
+                           List(
+                             "datum3",
+                           ),
+                         )
+        _              = getK(r3).continuation.results should contain.oneOf(
+                           List("datum1"),
+                           List("datum2"),
+                           List(
+                             "datum3",
+                           ),
+                         )
+        _              = getK(r1).continuation.results shouldNot contain theSameElementsAs getK(r2).continuation.results
+        _              = getK(r1).continuation.results shouldNot contain theSameElementsAs getK(r3).continuation.results
+        _              = getK(r2).continuation.results shouldNot contain theSameElementsAs getK(r3).continuation.results
         insertActions <- store.changes.map(collectActions[InsertAction])
-        _             = insertActions shouldBe empty
+        _              = insertActions shouldBe empty
       } yield ()
-  }
+    }
 
   "consuming three times on the same channel with non-trivial matches, then producing three times on that channel" should
     "return three continuations, each paired with matching data" in fixture { (store, _, space) =>
-    for {
-      _ <- space.consume(
-            List("ch1"),
-            List(StringMatch("datum1")),
-            new StringsCaptor,
-            persist = false
-          )
-      _ <- space.consume(
-            List("ch1"),
-            List(StringMatch("datum2")),
-            new StringsCaptor,
-            persist = false
-          )
-      _ <- space.consume(
-            List("ch1"),
-            List(StringMatch("datum3")),
-            new StringsCaptor,
-            persist = false
-          )
+      for {
+        _ <- space.consume(
+               List("ch1"),
+               List(StringMatch("datum1")),
+               new StringsCaptor,
+               persist = false,
+             )
+        _ <- space.consume(
+               List("ch1"),
+               List(StringMatch("datum2")),
+               new StringsCaptor,
+               persist = false,
+             )
+        _ <- space.consume(
+               List("ch1"),
+               List(StringMatch("datum3")),
+               new StringsCaptor,
+               persist = false,
+             )
 
-      r1 <- space.produce("ch1", "datum1", persist = false)
-      r2 <- space.produce("ch1", "datum2", persist = false)
-      r3 <- space.produce("ch1", "datum3", persist = false)
+        r1 <- space.produce("ch1", "datum1", persist = false)
+        r2 <- space.produce("ch1", "datum2", persist = false)
+        r3 <- space.produce("ch1", "datum3", persist = false)
 
-      _ = r1 shouldBe defined
-      _ = r2 shouldBe defined
-      _ = r3 shouldBe defined
+        _ = r1 shouldBe defined
+        _ = r2 shouldBe defined
+        _ = r3 shouldBe defined
 
-      _ = List(r1, r2, r3)
-        .map(unpackOption)
-        .foreach(runK)
+        _ = List(r1, r2, r3)
+              .map(unpackOption)
+              .foreach(runK)
 
-      _             = getK(r1).continuation.results shouldBe List(List("datum1"))
-      _             = getK(r2).continuation.results shouldBe List(List("datum2"))
-      _             = getK(r3).continuation.results shouldBe List(List("datum3"))
-      insertActions <- store.changes.map(collectActions[InsertAction])
-    } yield (insertActions shouldBe empty)
-  }
+        _              = getK(r1).continuation.results shouldBe List(List("datum1"))
+        _              = getK(r2).continuation.results shouldBe List(List("datum2"))
+        _              = getK(r3).continuation.results shouldBe List(List("datum3"))
+        insertActions <- store.changes.map(collectActions[InsertAction])
+      } yield insertActions shouldBe empty
+    }
 
   "consuming on two channels, producing on one, then producing on the other" should
     "return a continuation with both pieces of data" in fixture { (store, _, space) =>
-    for {
-      r1 <- space.consume(
-             List("ch1", "ch2"),
-             List(Wildcard, Wildcard),
-             new StringsCaptor,
-             persist = false
-           )
-      r2 <- space.produce("ch1", "datum1", persist = false)
-      r3 <- space.produce("ch2", "datum2", persist = false)
+      for {
+        r1 <- space.consume(
+                List("ch1", "ch2"),
+                List(Wildcard, Wildcard),
+                new StringsCaptor,
+                persist = false,
+              )
+        r2 <- space.produce("ch1", "datum1", persist = false)
+        r3 <- space.produce("ch2", "datum2", persist = false)
 
-      _ = r1 shouldBe None
-      _ = r2 shouldBe None
-      _ = r3 shouldBe defined
+        _ = r1 shouldBe None
+        _ = r2 shouldBe None
+        _ = r3 shouldBe defined
 
-      _ = runK(unpackOption(r3))
+        _ = runK(unpackOption(r3))
 
-      _ = getK(r3).continuation.results should contain theSameElementsAs List(
-        List("datum1", "datum2")
-      )
-      insertActions <- store.changes.map(collectActions[InsertAction])
-    } yield (insertActions shouldBe empty)
+        _              = getK(r3).continuation.results should contain theSameElementsAs List(
+                           List("datum1", "datum2"),
+                         )
+        insertActions <- store.changes.map(collectActions[InsertAction])
+      } yield insertActions shouldBe empty
 
-  }
+    }
 
   "A joined consume with the same channel given twice followed by a produce" should
     "not raise any errors (CORE-365)" in fixture { (store, _, space) =>
-    val channels = List("ch1", "ch1")
+      val channels = List("ch1", "ch1")
 
-    for {
-      r1 <- space.consume(
-             channels,
-             List(StringMatch("datum1"), StringMatch("datum1")),
-             new StringsCaptor,
-             persist = false
-           )
+      for {
+        r1 <- space.consume(
+                channels,
+                List(StringMatch("datum1"), StringMatch("datum1")),
+                new StringsCaptor,
+                persist = false,
+              )
 
-      r2 <- space.produce("ch1", "datum1", persist = false)
-      r3 <- space.produce("ch1", "datum1", persist = false)
+        r2 <- space.produce("ch1", "datum1", persist = false)
+        r3 <- space.produce("ch1", "datum1", persist = false)
 
-      _ = r1 shouldBe None
-      _ = r2 shouldBe None
-      _ = r3 shouldBe defined
+        _ = r1 shouldBe None
+        _ = r2 shouldBe None
+        _ = r3 shouldBe defined
 
-      _             = runK(unpackOption(r3))
-      _             = getK(r3).continuation.results shouldBe List(List("datum1", "datum1"))
-      insertActions <- store.changes.map(collectActions[InsertAction])
-    } yield (insertActions shouldBe empty)
-  }
+        _              = runK(unpackOption(r3))
+        _              = getK(r3).continuation.results shouldBe List(List("datum1", "datum1"))
+        insertActions <- store.changes.map(collectActions[InsertAction])
+      } yield insertActions shouldBe empty
+    }
 
   "consuming twice on the same channels with different patterns, and then producing on those channels" should
     "return continuations with the expected data" in fixture { (store, _, space) =>
-    val channels = List("ch1", "ch2")
+      val channels = List("ch1", "ch2")
 
-    for {
-      r1 <- space.consume(
-             channels,
-             List(StringMatch("datum1"), StringMatch("datum2")),
-             new StringsCaptor,
-             persist = false
-           )
-      r2 <- space.consume(
-             channels,
-             List(StringMatch("datum3"), StringMatch("datum4")),
-             new StringsCaptor,
-             persist = false
-           )
+      for {
+        r1 <- space.consume(
+                channels,
+                List(StringMatch("datum1"), StringMatch("datum2")),
+                new StringsCaptor,
+                persist = false,
+              )
+        r2 <- space.consume(
+                channels,
+                List(StringMatch("datum3"), StringMatch("datum4")),
+                new StringsCaptor,
+                persist = false,
+              )
 
-      r3 <- space.produce("ch1", "datum3", persist = false)
-      r4 <- space.produce("ch2", "datum4", persist = false)
-      r5 <- space.produce("ch1", "datum1", persist = false)
-      r6 <- space.produce("ch2", "datum2", persist = false)
+        r3 <- space.produce("ch1", "datum3", persist = false)
+        r4 <- space.produce("ch2", "datum4", persist = false)
+        r5 <- space.produce("ch1", "datum1", persist = false)
+        r6 <- space.produce("ch2", "datum2", persist = false)
 
-      _ = r1 shouldBe None
-      _ = r2 shouldBe None
-      _ = r3 shouldBe None
-      _ = r4 shouldBe defined
-      _ = r5 shouldBe None
-      _ = r6 shouldBe defined
+        _ = r1 shouldBe None
+        _ = r2 shouldBe None
+        _ = r3 shouldBe None
+        _ = r4 shouldBe defined
+        _ = r5 shouldBe None
+        _ = r6 shouldBe defined
 
-      _ = List(r4, r6)
-        .map(unpackOption)
-        .foreach(runK)
+        _ = List(r4, r6)
+              .map(unpackOption)
+              .foreach(runK)
 
-      _ = getK(r4).continuation.results should contain theSameElementsAs List(
-        List("datum3", "datum4")
-      )
-      _ = getK(r6).continuation.results should contain theSameElementsAs List(
-        List("datum1", "datum2")
-      )
-      insertActions <- store.changes.map(collectActions[InsertAction])
-    } yield (insertActions shouldBe empty)
+        _              = getK(r4).continuation.results should contain theSameElementsAs List(
+                           List("datum3", "datum4"),
+                         )
+        _              = getK(r6).continuation.results should contain theSameElementsAs List(
+                           List("datum1", "datum2"),
+                         )
+        insertActions <- store.changes.map(collectActions[InsertAction])
+      } yield insertActions shouldBe empty
 
-  }
+    }
 
   "consuming and producing with non-trivial matches" should "work" in fixture { (store, _, space) =>
     for {
       r1 <- space.consume(
-             List("ch1", "ch2"),
-             List(Wildcard, StringMatch("datum1")),
-             new StringsCaptor,
-             persist = false
-           )
+              List("ch1", "ch2"),
+              List(Wildcard, StringMatch("datum1")),
+              new StringsCaptor,
+              persist = false,
+            )
       r2 <- space.produce("ch1", "datum1", persist = false)
 
       _ = r1 shouldBe None
       _ = r2 shouldBe None
 
       d1 <- store.getData("ch2")
-      _  = d1 shouldBe Nil
+      _   = d1 shouldBe Nil
       d2 <- store.getData("ch1")
-      _  = d2 shouldBe List(Datum.create("ch1", "datum1", false))
+      _   = d2 shouldBe List(Datum.create("ch1", "datum1", false))
 
       c1 <- store.getContinuations(List("ch1", "ch2"))
-      _  = c1 should not be empty
+      _   = c1 should not be empty
       j1 <- store.getJoins("ch1")
-      _  = j1 shouldBe List(List("ch1", "ch2"))
+      _   = j1 shouldBe List(List("ch1", "ch2"))
       j2 <- store.getJoins("ch2")
-      _  = j2 shouldBe List(List("ch1", "ch2"))
+      _   = j2 shouldBe List(List("ch1", "ch2"))
 
       insertActions <- store.changes.map(collectActions[InsertAction])
-    } yield (insertActions should not be empty)
+    } yield insertActions should not be empty
 
   }
 
   "consuming twice and producing twice with non-trivial matches" should
     "work" in fixture { (store, _, space) =>
-    for {
-      r1 <- space.consume(
-             List("ch1"),
-             List(StringMatch("datum1")),
-             new StringsCaptor,
-             persist = false
-           )
-      r2 <- space.consume(
-             List("ch2"),
-             List(StringMatch("datum2")),
-             new StringsCaptor,
-             persist = false
-           )
-      r3 <- space.produce("ch1", "datum1", persist = false)
-      r4 <- space.produce("ch2", "datum2", persist = false)
+      for {
+        r1 <- space.consume(
+                List("ch1"),
+                List(StringMatch("datum1")),
+                new StringsCaptor,
+                persist = false,
+              )
+        r2 <- space.consume(
+                List("ch2"),
+                List(StringMatch("datum2")),
+                new StringsCaptor,
+                persist = false,
+              )
+        r3 <- space.produce("ch1", "datum1", persist = false)
+        r4 <- space.produce("ch2", "datum2", persist = false)
 
-      _ = List(r1, r2, r3, r4)
-        .map(unpackOption)
-        .foreach(runK)
+        _ = List(r1, r2, r3, r4)
+              .map(unpackOption)
+              .foreach(runK)
 
-      d1 <- store.getData("ch1")
-      _  = d1 shouldBe Nil
-      d2 <- store.getData("ch2")
-      _  = d2 shouldBe Nil
+        d1 <- store.getData("ch1")
+        _   = d1 shouldBe Nil
+        d2 <- store.getData("ch2")
+        _   = d2 shouldBe Nil
 
-      _             = getK(r3).continuation.results should contain theSameElementsAs List(List("datum1"))
-      _             = getK(r4).continuation.results should contain theSameElementsAs List(List("datum2"))
-      insertActions <- store.changes.map(collectActions[InsertAction])
-    } yield (insertActions shouldBe empty)
-  }
+        _              = getK(r3).continuation.results should contain theSameElementsAs List(List("datum1"))
+        _              = getK(r4).continuation.results should contain theSameElementsAs List(List("datum2"))
+        insertActions <- store.changes.map(collectActions[InsertAction])
+      } yield insertActions shouldBe empty
+    }
 
   "consuming on two channels, consuming on one of those channels, and then producing on both of those channels separately" should
     "return a continuation paired with one piece of data" in
     fixture { (store, _, space) =>
       for {
         _ <- space.consume(
-              List("ch1", "ch2"),
-              List(Wildcard, Wildcard),
-              new StringsCaptor,
-              persist = false
-            )
+               List("ch1", "ch2"),
+               List(Wildcard, Wildcard),
+               new StringsCaptor,
+               persist = false,
+             )
         _ <- space.consume(List("ch1"), List(Wildcard), new StringsCaptor, persist = false)
 
         r3 <- space.produce("ch1", "datum1", persist = false)
@@ -679,158 +676,155 @@ trait StorageActionsTests[F[_]]
 
         _ = runK(unpackOption(r3))
 
-        _ = getK(r3).continuation.results should contain theSameElementsAs List(List("datum1"))
-        //ensure that joins are cleaned-up after all
+        _              = getK(r3).continuation.results should contain theSameElementsAs List(List("datum1"))
+        // ensure that joins are cleaned-up after all
         _             <- store.getJoins("ch1").map(_ shouldBe List(List("ch1", "ch2")))
         _             <- store.getJoins("ch2").map(_ shouldBe List(List("ch1", "ch2")))
         insertActions <- store.changes.map(collectActions[InsertAction])
-      } yield (insertActions should not be empty)
+      } yield insertActions should not be empty
     }
 
   /* Persist tests */
 
   "producing and then doing a persistent consume on the same channel" should
     "return the continuation and data" in fixture { (store, _, space) =>
-    val key = List("ch1")
+      val key = List("ch1")
 
-    for {
-      r1 <- space.produce(key.head, "datum", persist = false)
-      _  <- store.getData(key.head).map(_ shouldBe List(Datum.create(key.head, "datum", false)))
-      _  <- store.getContinuations(key).map(_ shouldBe Nil)
-      _  = r1 shouldBe None
+      for {
+        r1 <- space.produce(key.head, "datum", persist = false)
+        _  <- store.getData(key.head).map(_ shouldBe List(Datum.create(key.head, "datum", false)))
+        _  <- store.getContinuations(key).map(_ shouldBe Nil)
+        _   = r1 shouldBe None
 
-      // Data exists so the write will not "stick"
-      r2            <- space.consume(key, List(Wildcard), new StringsCaptor, persist = true)
-      _             = r2 shouldBe defined
-      insertActions <- store.changes.map(collectActions[InsertAction])
-      _             = insertActions shouldBe empty
+        // Data exists so the write will not "stick"
+        r2            <- space.consume(key, List(Wildcard), new StringsCaptor, persist = true)
+        _              = r2 shouldBe defined
+        insertActions <- store.changes.map(collectActions[InsertAction])
+        _              = insertActions shouldBe empty
 
-      _ = runK(unpackOption(r2))
+        _ = runK(unpackOption(r2))
 
-      _ = getK(r2).continuation.results should contain theSameElementsAs List(List("datum"))
+        _ = getK(r2).continuation.results should contain theSameElementsAs List(List("datum"))
 
-      // the data has been consumed, so the write will "stick"
-      r3 <- space.consume(key, List(Wildcard), new StringsCaptor, persist = true)
-      _  <- store.getData(key.head).map(_ shouldBe Nil)
-      _  <- store.getContinuations(key).map(_ should not be empty)
-    } yield (r3 shouldBe None)
-  }
+        // the data has been consumed, so the write will "stick"
+        r3 <- space.consume(key, List(Wildcard), new StringsCaptor, persist = true)
+        _  <- store.getData(key.head).map(_ shouldBe Nil)
+        _  <- store.getContinuations(key).map(_ should not be empty)
+      } yield r3 shouldBe None
+    }
 
   "producing, doing a persistent consume, and producing again on the same channel" should
-    "return the continuation for the first produce, and then the second produce" in fixture {
-    (store, _, space) =>
+    "return the continuation for the first produce, and then the second produce" in fixture { (store, _, space) =>
       val key = List("ch1")
 
       for {
         r1 <- space.produce(key.head, "datum1", persist = false)
         _  <- store.getData(key.head).map(_ shouldBe List(Datum.create(key.head, "datum1", false)))
         _  <- store.getContinuations(key).map(_ shouldBe Nil)
-        _  = r1 shouldBe None
+        _   = r1 shouldBe None
 
         // Matching data exists so the write will not "stick"
         r2            <- space.consume(key, List(Wildcard), new StringsCaptor, persist = true)
-        _             = r2 shouldBe defined
+        _              = r2 shouldBe defined
         insertActions <- store.changes.map(collectActions[InsertAction])
-        _             = insertActions shouldBe empty
+        _              = insertActions shouldBe empty
 
         _ = runK(unpackOption(r2))
         _ = getK(r2).continuation.results should contain theSameElementsAs List(List("datum1"))
 
         // All matching data has been consumed, so the write will "stick"
         r3 <- space.consume(key, List(Wildcard), new StringsCaptor, persist = true)
-        _  = r3 shouldBe None
+        _   = r3 shouldBe None
 
         _ <- store.getData(key.head).map(_ shouldBe Nil)
         _ <- store.getContinuations(key).map(_ should not be empty)
 
         r4 <- space.produce(key.head, "datum2", persist = false)
-        _  = r4 shouldBe defined
+        _   = r4 shouldBe defined
         _  <- store.getData(key.head).map(_ shouldBe Nil)
         _  <- store.getContinuations(key).map(_ should not be empty)
 
         _ = runK(unpackOption(r4))
       } yield getK(r4).continuation.results should contain theSameElementsAs List(List("datum2"))
-  }
+    }
 
-  "doing a persistent consume and producing multiple times" should "work" in fixture {
-    (store, _, space) =>
-      for {
-        r1 <- space.consume(List("ch1"), List(Wildcard), new StringsCaptor, persist = true)
-        _  <- store.getData("ch1").map(_ shouldBe Nil)
-        _  <- store.getContinuations(List("ch1")).map(_ should not be empty)
-        _  = r1 shouldBe None
+  "doing a persistent consume and producing multiple times" should "work" in fixture { (store, _, space) =>
+    for {
+      r1 <- space.consume(List("ch1"), List(Wildcard), new StringsCaptor, persist = true)
+      _  <- store.getData("ch1").map(_ shouldBe Nil)
+      _  <- store.getContinuations(List("ch1")).map(_ should not be empty)
+      _   = r1 shouldBe None
 
-        r2 <- space.produce("ch1", "datum1", persist = false)
-        _  <- store.getData("ch1").map(_ shouldBe Nil)
-        _  <- store.getContinuations(List("ch1")).map(_ should not be empty)
-        _  = r2 shouldBe defined
+      r2 <- space.produce("ch1", "datum1", persist = false)
+      _  <- store.getData("ch1").map(_ shouldBe Nil)
+      _  <- store.getContinuations(List("ch1")).map(_ should not be empty)
+      _   = r2 shouldBe defined
 
-        _ = runK(unpackOption(r2))
-        _ = getK(r2).continuation.results should contain theSameElementsAs List(List("datum1"))
+      _ = runK(unpackOption(r2))
+      _ = getK(r2).continuation.results should contain theSameElementsAs List(List("datum1"))
 
-        r3 <- space.produce("ch1", "datum2", persist = false)
-        _  <- store.getData("ch1").map(_ shouldBe Nil)
-        _  <- store.getContinuations(List("ch1")).map(_ should not be empty)
+      r3 <- space.produce("ch1", "datum2", persist = false)
+      _  <- store.getData("ch1").map(_ shouldBe Nil)
+      _  <- store.getContinuations(List("ch1")).map(_ should not be empty)
 
-        _ = r3 shouldBe defined
-        _ = runK(unpackOption(r3))
-      } yield getK(r3).continuation.results should contain theSameElementsAs List(
-        List("datum1"),
-        List("datum2")
-      )
+      _ = r3 shouldBe defined
+      _ = runK(unpackOption(r3))
+    } yield getK(r3).continuation.results should contain theSameElementsAs List(
+      List("datum1"),
+      List("datum2"),
+    )
   }
 
   "consuming and doing a persistient produce" should "work" in fixture { (store, _, space) =>
     for {
       r1 <- space.consume(List("ch1"), List(Wildcard), new StringsCaptor, persist = false)
-      _  = r1 shouldBe None
+      _   = r1 shouldBe None
 
       // A matching continuation exists so the write will not "stick"
       r2            <- space.produce("ch1", "datum1", persist = true)
-      _             = r2 shouldBe defined
+      _              = r2 shouldBe defined
       insertActions <- store.changes.map(collectActions[InsertAction])
-      _             = insertActions shouldBe empty
+      _              = insertActions shouldBe empty
 
       _ = runK(unpackOption(r2))
       _ = getK(r2).continuation.results should contain theSameElementsAs List(List("datum1"))
 
       // All matching continuations have been produced, so the write will "stick"
       r3 <- space.produce("ch1", "datum1", persist = true)
-      _  = r3 shouldBe None
+      _   = r3 shouldBe None
       _  <- store.getData("ch1").map(_ shouldBe List(Datum.create("ch1", "datum1", true)))
       _  <- store.getContinuations(List("ch1")) map (_ shouldBe Nil)
     } yield ()
   }
 
-  "consuming, doing a persistient produce, and consuming again" should "work" in fixture {
-    (store, _, space) =>
-      for {
-        r1 <- space.consume(List("ch1"), List(Wildcard), new StringsCaptor, persist = false)
+  "consuming, doing a persistient produce, and consuming again" should "work" in fixture { (store, _, space) =>
+    for {
+      r1 <- space.consume(List("ch1"), List(Wildcard), new StringsCaptor, persist = false)
 
-        _ = r1 shouldBe None
+      _ = r1 shouldBe None
 
-        // A matching continuation exists so the write will not "stick"
-        r2            <- space.produce("ch1", "datum1", persist = true)
-        _             = r2 shouldBe defined
-        insertActions <- store.changes.map(collectActions[InsertAction])
-        _             = insertActions shouldBe empty
+      // A matching continuation exists so the write will not "stick"
+      r2            <- space.produce("ch1", "datum1", persist = true)
+      _              = r2 shouldBe defined
+      insertActions <- store.changes.map(collectActions[InsertAction])
+      _              = insertActions shouldBe empty
 
-        _ = runK(unpackOption(r2))
-        _ = getK(r2).continuation.results should contain theSameElementsAs List(List("datum1"))
+      _ = runK(unpackOption(r2))
+      _ = getK(r2).continuation.results should contain theSameElementsAs List(List("datum1"))
 
-        // All matching continuations have been produced, so the write will "stick"
-        r3 <- space.produce("ch1", "datum1", persist = true)
-        _  = r3 shouldBe None
-        _  <- store.getData("ch1") map (_ shouldBe List(Datum.create("ch1", "datum1", true)))
-        _  <- store.getContinuations(List("ch1")) map (_ shouldBe Nil)
+      // All matching continuations have been produced, so the write will "stick"
+      r3 <- space.produce("ch1", "datum1", persist = true)
+      _   = r3 shouldBe None
+      _  <- store.getData("ch1") map (_ shouldBe List(Datum.create("ch1", "datum1", true)))
+      _  <- store.getContinuations(List("ch1")) map (_ shouldBe Nil)
 
-        r4 <- space.consume(List("ch1"), List(Wildcard), new StringsCaptor, persist = false)
-        _  = r4 shouldBe defined
-        _  <- store.getData("ch1") map (_ shouldBe List(Datum.create("ch1", "datum1", true)))
-        _  <- store.getContinuations(List("ch1")) map (_ shouldBe Nil)
+      r4 <- space.consume(List("ch1"), List(Wildcard), new StringsCaptor, persist = false)
+      _   = r4 shouldBe defined
+      _  <- store.getData("ch1") map (_ shouldBe List(Datum.create("ch1", "datum1", true)))
+      _  <- store.getContinuations(List("ch1")) map (_ shouldBe Nil)
 
-        _ = runK(unpackOption(r4))
-      } yield getK(r4).continuation.results should contain theSameElementsAs List(List("datum1"))
+      _ = runK(unpackOption(r4))
+    } yield getK(r4).continuation.results should contain theSameElementsAs List(List("datum1"))
   }
 
   "doing a persistent produce and consuming twice" should "work" in fixture { (store, _, space) =>
@@ -838,12 +832,12 @@ trait StorageActionsTests[F[_]]
       r1 <- space.produce("ch1", "datum1", persist = true)
       _  <- store.getData("ch1") map (_ shouldBe List(Datum.create("ch1", "datum1", true)))
       _  <- store.getContinuations(List("ch1")) map (_ shouldBe Nil)
-      _  = r1 shouldBe None
+      _   = r1 shouldBe None
 
       r2 <- space.consume(List("ch1"), List(Wildcard), new StringsCaptor, persist = false)
       _  <- store.getData("ch1") map (_ shouldBe List(Datum.create("ch1", "datum1", true)))
       _  <- store.getContinuations(List("ch1")) map (_ shouldBe Nil)
-      _  = r2 shouldBe defined
+      _   = r2 shouldBe defined
 
       _ = runK(unpackOption(r2))
       _ = getK(r2).continuation.results should contain theSameElementsAs List(List("datum1"))
@@ -857,95 +851,93 @@ trait StorageActionsTests[F[_]]
     } yield getK(r3).continuation.results should contain theSameElementsAs List(List("datum1"))
   }
 
-  "producing three times and doing a persistent consume" should "work" in fixture {
-    (store, _, space) =>
-      for {
-        r1 <- space.produce("ch1", "datum1", persist = false)
-        r2 <- space.produce("ch1", "datum2", persist = false)
-        r3 <- space.produce("ch1", "datum3", persist = false)
+  "producing three times and doing a persistent consume" should "work" in fixture { (store, _, space) =>
+    for {
+      r1 <- space.produce("ch1", "datum1", persist = false)
+      r2 <- space.produce("ch1", "datum2", persist = false)
+      r3 <- space.produce("ch1", "datum3", persist = false)
 
-        _ = r1 shouldBe None
-        _ = r2 shouldBe None
-        _ = r3 shouldBe None
+      _ = r1 shouldBe None
+      _ = r2 shouldBe None
+      _ = r3 shouldBe None
 
-        // Matching data exists so the write will not "stick"
-        r4 <- space.consume(List("ch1"), List(Wildcard), new StringsCaptor, persist = true)
-        _ <- store.getData("ch1") map (_ should contain.atLeastOneOf(
+      // Matching data exists so the write will not "stick"
+      r4 <- space.consume(List("ch1"), List(Wildcard), new StringsCaptor, persist = true)
+      _  <- store.getData("ch1") map (_ should contain.atLeastOneOf(
               Datum.create("ch1", "datum1", false),
               Datum.create("ch1", "datum2", false),
-              Datum.create("ch1", "datum3", false)
+              Datum.create("ch1", "datum3", false),
             ))
-        _ <- store.getContinuations(List("ch1")) map (_ shouldBe Nil)
-        _ = r4 shouldBe defined
+      _  <- store.getContinuations(List("ch1")) map (_ shouldBe Nil)
+      _   = r4 shouldBe defined
 
-        _ = runK(unpackOption(r4))
-        _ = getK(r4).continuation.results should contain.oneOf(
-          List("datum1"),
-          List("datum2"),
-          List(
-            "datum3"
-          )
-        )
+      _   = runK(unpackOption(r4))
+      _   = getK(r4).continuation.results should contain.oneOf(
+              List("datum1"),
+              List("datum2"),
+              List(
+                "datum3",
+              ),
+            )
 
-        // Matching data exists so the write will not "stick"
-        r5 <- space.consume(List("ch1"), List(Wildcard), new StringsCaptor, persist = true)
-        _ <- store.getData("ch1") map (_ should contain.oneOf(
+      // Matching data exists so the write will not "stick"
+      r5 <- space.consume(List("ch1"), List(Wildcard), new StringsCaptor, persist = true)
+      _  <- store.getData("ch1") map (_ should contain.oneOf(
               Datum.create("ch1", "datum1", false),
               Datum.create("ch1", "datum2", false),
-              Datum.create("ch1", "datum3", false)
+              Datum.create("ch1", "datum3", false),
             ))
-        _ <- store.getContinuations(List("ch1")) map (_ shouldBe Nil)
-        _ = r5 shouldBe defined
+      _  <- store.getContinuations(List("ch1")) map (_ shouldBe Nil)
+      _   = r5 shouldBe defined
 
-        _ = runK(unpackOption(r5))
-        _ = getK(r5).continuation.results should contain.oneOf(
-          List("datum1"),
-          List("datum2"),
-          List(
-            "datum3"
-          )
-        )
+      _              = runK(unpackOption(r5))
+      _              = getK(r5).continuation.results should contain.oneOf(
+                         List("datum1"),
+                         List("datum2"),
+                         List(
+                           "datum3",
+                         ),
+                       )
 
-        // Matching data exists so the write will not "stick"
-        r6            <- space.consume(List("ch1"), List(Wildcard), new StringsCaptor, persist = true)
-        insertActions <- store.changes.map(collectActions[InsertAction])
-        _             = insertActions shouldBe empty
-        _             = r6 shouldBe defined
+      // Matching data exists so the write will not "stick"
+      r6            <- space.consume(List("ch1"), List(Wildcard), new StringsCaptor, persist = true)
+      insertActions <- store.changes.map(collectActions[InsertAction])
+      _              = insertActions shouldBe empty
+      _              = r6 shouldBe defined
 
-        _ = runK(unpackOption(r6))
-        _ = getK(r6).continuation.results should contain.oneOf(
-          List("datum1"),
-          List("datum2"),
-          List(
-            "datum3"
-          )
-        )
+      _   = runK(unpackOption(r6))
+      _   = getK(r6).continuation.results should contain.oneOf(
+              List("datum1"),
+              List("datum2"),
+              List(
+                "datum3",
+              ),
+            )
 
-        // All matching data has been consumed, so the write will "stick"
-        r7 <- space.consume(List("ch1"), List(Wildcard), new StringsCaptor, persist = true)
-        _  <- store.getData("ch1") map (_ shouldBe Nil)
-        _  <- store.getContinuations(List("ch1")) map (_ should not be empty)
-      } yield (r7 shouldBe None)
+      // All matching data has been consumed, so the write will "stick"
+      r7 <- space.consume(List("ch1"), List(Wildcard), new StringsCaptor, persist = true)
+      _  <- store.getData("ch1") map (_ shouldBe Nil)
+      _  <- store.getContinuations(List("ch1")) map (_ should not be empty)
+    } yield r7 shouldBe None
 
   }
 
-  "A persistent produce" should "be available for multiple matches (CORE-633)" in fixture {
-    (store, _, space) =>
-      val channel = "chan"
+  "A persistent produce" should "be available for multiple matches (CORE-633)" in fixture { (store, _, space) =>
+    val channel = "chan"
 
-      for {
-        r1 <- space.produce(channel, data = "datum", persist = true)
-        _  = r1 shouldBe None
+    for {
+      r1 <- space.produce(channel, data = "datum", persist = true)
+      _   = r1 shouldBe None
 
-        r2 <- space.consume(
-               List(channel, channel),
-               List(Wildcard, Wildcard),
-               new StringsCaptor,
-               persist = false
-             )
-        _ = r2 shouldBe defined
-        _ = runK(unpackOption(r2))
-      } yield getK(r2).continuation.results should contain(List("datum", "datum"))
+      r2 <- space.consume(
+              List(channel, channel),
+              List(Wildcard, Wildcard),
+              new StringsCaptor,
+              persist = false,
+            )
+      _   = r2 shouldBe defined
+      _   = runK(unpackOption(r2))
+    } yield getK(r2).continuation.results should contain(List("datum", "datum"))
   }
 
   "clear" should "reset to the same hash on multiple runs" in fixture { (store, _, space) =>
@@ -954,22 +946,21 @@ trait StorageActionsTests[F[_]]
 
     for {
       emptyCheckpoint <- space.createCheckpoint()
-      //put some data so the checkpoint is != empty
-      _           <- space.consume(key, patterns, new StringsCaptor, persist = false)
-      checkpoint0 <- space.createCheckpoint()
-      _           = checkpoint0.log should not be empty
-      _           <- space.createCheckpoint()
-      //force clearing of trie store state
-      _ <- space.clear()
-      //the checkpointing mechanism should not interfere with the empty root
-      checkpoint2 <- space.createCheckpoint()
-      _           = checkpoint2.log shouldBe empty
+      // put some data so the checkpoint is != empty
+      _               <- space.consume(key, patterns, new StringsCaptor, persist = false)
+      checkpoint0     <- space.createCheckpoint()
+      _                = checkpoint0.log should not be empty
+      _               <- space.createCheckpoint()
+      // force clearing of trie store state
+      _               <- space.clear()
+      // the checkpointing mechanism should not interfere with the empty root
+      checkpoint2     <- space.createCheckpoint()
+      _                = checkpoint2.log shouldBe empty
     } yield checkpoint2.root shouldBe emptyCheckpoint.root
   }
 
-  "createCheckpoint on an empty store" should "return the expected hash" in fixture {
-    (_, _, space) =>
-      space.createCheckpoint().map(_.root shouldBe emptyRootHash)
+  "createCheckpoint on an empty store" should "return the expected hash" in fixture { (_, _, space) =>
+    space.createCheckpoint().map(_.root shouldBe emptyRootHash)
   }
 
   "createCheckpoint" should "clear the store contents" in fixture { (_, storeRef, space) =>
@@ -981,35 +972,34 @@ trait StorageActionsTests[F[_]]
       _                  <- space.createCheckpoint()
       store0             <- storeRef.get
       checkpoint0Changes <- store0.changes
-      _                  = checkpoint0Changes.length shouldBe 0
+      _                   = checkpoint0Changes.length shouldBe 0
     } yield ()
   }
 
-  "reset" should "change the state of the store, and reset the trie updates log" in fixture {
-    (_, storeRef, space) =>
-      val key      = List("ch1")
-      val patterns = List(Wildcard)
+  "reset" should "change the state of the store, and reset the trie updates log" in fixture { (_, storeRef, space) =>
+    val key      = List("ch1")
+    val patterns = List(Wildcard)
 
-      for {
-        checkpoint0          <- space.createCheckpoint()
-        r                    <- space.consume(key, patterns, new StringsCaptor, persist = false)
-        _                    = r shouldBe None
-        postCheckpoint0Store <- storeRef.get
-        checkpoint0Changes <- postCheckpoint0Store.changes
-                               .map(
-                                 collectActions[InsertContinuations[String, Pattern, StringsCaptor]]
-                               )
-        _ = checkpoint0Changes.isEmpty shouldBe false
-        _ = checkpoint0Changes.length shouldBe 1
+    for {
+      checkpoint0          <- space.createCheckpoint()
+      r                    <- space.consume(key, patterns, new StringsCaptor, persist = false)
+      _                     = r shouldBe None
+      postCheckpoint0Store <- storeRef.get
+      checkpoint0Changes   <- postCheckpoint0Store.changes
+                                .map(
+                                  collectActions[InsertContinuations[String, Pattern, StringsCaptor]],
+                                )
+      _                     = checkpoint0Changes.isEmpty shouldBe false
+      _                     = checkpoint0Changes.length shouldBe 1
 
-        _              <- space.reset(checkpoint0.root)
-        postResetStore <- storeRef.get
-        resetChanges   <- postResetStore.changes
-        _              = resetChanges.isEmpty shouldBe true
-        _              = resetChanges.length shouldBe 0
+      _              <- space.reset(checkpoint0.root)
+      postResetStore <- storeRef.get
+      resetChanges   <- postResetStore.changes
+      _               = resetChanges.isEmpty shouldBe true
+      _               = resetChanges.length shouldBe 0
 
-        checkpoint1 <- space.createCheckpoint()
-      } yield checkpoint1.log shouldBe empty
+      checkpoint1 <- space.createCheckpoint()
+    } yield checkpoint1.log shouldBe empty
   }
 
   "consume and produce a match and then createCheckpoint" should "result in an empty TrieStore" in
@@ -1018,13 +1008,13 @@ trait StorageActionsTests[F[_]]
 
       for {
         checkpointInit <- space.createCheckpoint()
-        _              = checkpointInit.root shouldBe emptyRootHash
+        _               = checkpointInit.root shouldBe emptyRootHash
         r1             <- space.consume(channels, List(Wildcard), new StringsCaptor, persist = false)
-        _              = r1 shouldBe None
+        _               = r1 shouldBe None
         r2             <- space.produce(channels.head, "datum", persist = false)
-        _              = r2 shouldBe defined
+        _               = r2 shouldBe defined
         checkpoint     <- space.createCheckpoint()
-        _              = checkpoint.root shouldBe emptyRootHash
+        _               = checkpoint.root shouldBe emptyRootHash
       } yield ()
     }
 
@@ -1035,7 +1025,7 @@ trait StorageActionsTests[F[_]]
           channel :: Nil,
           List(Wildcard),
           new StringsCaptor,
-          persist = false
+          persist = false,
         )
         for {
           _           <- data.traverse(channel => space.produce(channel, "data", false))
@@ -1043,11 +1033,11 @@ trait StorageActionsTests[F[_]]
           _           <- data.traverse(channel => consume(channel).map(_ shouldBe defined))
           checkpoint2 <- space.createCheckpoint()
           _           <- data.traverse(channel => consume(channel).map(_ shouldBe empty))
-          _           = checkpoint2.root shouldBe emptyRootHash
+          _            = checkpoint2.root shouldBe emptyRootHash
           _           <- space.reset(checkpoint1.root)
           _           <- data.traverse(channel => consume(channel).map(_ shouldBe defined))
           checkpoint3 <- space.createCheckpoint()
-          _           = checkpoint3.root shouldBe emptyRootHash
+          _            = checkpoint3.root shouldBe emptyRootHash
         } yield ()
       }
     }
@@ -1061,53 +1051,52 @@ trait StorageActionsTests[F[_]]
     for {
       _   <- space.produce(channel, datum, persist = false)
       res <- Sync[F].attempt(space.install(key, patterns, new StringsCaptor))
-      ex  = res.left.value
+      ex   = res.left.value
     } yield ex.getMessage shouldBe "Installing can be done only on startup"
   }
 
   "consuming with a list of patterns that is a different length than the list of channels" should
     "raise error" in fixture { (store, _, space) =>
-    for {
-      res <- Sync[F].attempt(
-              space.consume(List("ch1", "ch2"), List(Wildcard), new StringsCaptor, persist = false)
-            )
-      err           = res.left.value
-      _             = err shouldBe an[IllegalArgumentException]
-      _             = err.getMessage shouldBe "channels.length must equal patterns.length"
-      insertActions <- store.changes.map(collectActions[InsertAction])
-    } yield insertActions shouldBe empty
-  }
-
-  "createSoftCheckpoint" should "capture the current state of the store" in fixture {
-    (_, _, space) =>
-      val channel      = "ch1"
-      val channels     = List(channel)
-      val patterns     = List(Wildcard)
-      val continuation = new StringsCaptor
-
-      val expectedContinuation = Seq(
-        WaitingContinuation
-          .create[String, Pattern, StringsCaptor](
-            channels,
-            patterns,
-            continuation,
-            persist = false,
-            SortedSet.empty
-          )
-      )
-
       for {
-        // do an operation
-        _ <- space.consume(channels, patterns, continuation, persist = false)
-        // create a soft checkpoint
-        s <- space.createSoftCheckpoint()
-        // assert that the snapshot contains the continuation
-        _ = s.cacheSnapshot.continuations.values should contain only expectedContinuation
-        // consume again
-        _ <- space.consume(channels, patterns, continuation, persist = false)
-        // assert that the snapshot contains only the first continuation
-        _ = s.cacheSnapshot.continuations.values should contain only expectedContinuation
-      } yield ()
+        res           <- Sync[F].attempt(
+                           space.consume(List("ch1", "ch2"), List(Wildcard), new StringsCaptor, persist = false),
+                         )
+        err            = res.left.value
+        _              = err shouldBe an[IllegalArgumentException]
+        _              = err.getMessage shouldBe "channels.length must equal patterns.length"
+        insertActions <- store.changes.map(collectActions[InsertAction])
+      } yield insertActions shouldBe empty
+    }
+
+  "createSoftCheckpoint" should "capture the current state of the store" in fixture { (_, _, space) =>
+    val channel      = "ch1"
+    val channels     = List(channel)
+    val patterns     = List(Wildcard)
+    val continuation = new StringsCaptor
+
+    val expectedContinuation = Seq(
+      WaitingContinuation
+        .create[String, Pattern, StringsCaptor](
+          channels,
+          patterns,
+          continuation,
+          persist = false,
+          SortedSet.empty,
+        ),
+    )
+
+    for {
+      // do an operation
+      _ <- space.consume(channels, patterns, continuation, persist = false)
+      // create a soft checkpoint
+      s <- space.createSoftCheckpoint()
+      // assert that the snapshot contains the continuation
+      _  = s.cacheSnapshot.continuations.values should contain only expectedContinuation
+      // consume again
+      _ <- space.consume(channels, patterns, continuation, persist = false)
+      // assert that the snapshot contains only the first continuation
+      _  = s.cacheSnapshot.continuations.values should contain only expectedContinuation
+    } yield ()
   }
 
   it should "create checkpoints which have separate state" in fixture { (_, _, space) =>
@@ -1123,22 +1112,22 @@ trait StorageActionsTests[F[_]]
         patterns,
         continuation,
         persist = false,
-        SortedSet.empty
+        SortedSet.empty,
       )
 
     for {
       // do an operation
-      _ <- space.consume(channels, patterns, continuation, persist = false)
+      _  <- space.consume(channels, patterns, continuation, persist = false)
       // create a soft checkpoint
       s1 <- space.createSoftCheckpoint()
       // assert that the snapshot contains the continuation
-      _ = s1.cacheSnapshot.continuations.values should contain only Seq(expectedContinuation)
+      _   = s1.cacheSnapshot.continuations.values should contain only Seq(expectedContinuation)
       // produce thus removing the continuation
       _  <- space.produce(channel, datum, persist = false)
       s2 <- space.createSoftCheckpoint()
       // assert that the first snapshot still contains the first continuation
-      _ = s1.cacheSnapshot.continuations.values should contain only Seq(expectedContinuation)
-      _ = s2.cacheSnapshot.continuations(channels) shouldBe empty
+      _   = s1.cacheSnapshot.continuations.values should contain only Seq(expectedContinuation)
+      _   = s2.cacheSnapshot.continuations(channels) shouldBe empty
     } yield ()
   }
 
@@ -1150,20 +1139,20 @@ trait StorageActionsTests[F[_]]
 
     for {
       // do an operation
-      _ <- space.consume(channels, patterns, continuation, persist = false)
+      _  <- space.consume(channels, patterns, continuation, persist = false)
       // create a soft checkpoint
       s1 <- space.createSoftCheckpoint()
       // the log contains the above operation
-      _ = s1.log should contain only
-        Consume[String, Pattern, StringsCaptor](
-          channels,
-          patterns,
-          continuation,
-          persistent = false
-        )
+      _   = s1.log should contain only
+              Consume[String, Pattern, StringsCaptor](
+                channels,
+                patterns,
+                continuation,
+                persistent = false,
+              )
       s2 <- space.createSoftCheckpoint()
       // assert that the event log has been cleared
-      _ = s2.log shouldBe empty
+      _   = s2.log shouldBe empty
     } yield ()
   }
 
@@ -1176,22 +1165,22 @@ trait StorageActionsTests[F[_]]
 
       for {
         // create an initial soft checkpoint
-        s1 <- space.createSoftCheckpoint()
+        s1      <- space.createSoftCheckpoint()
         // do an operation
-        _      <- space.consume(channels, patterns, continuation, persist = false)
-        store1 <- storeRef.get
+        _       <- space.consume(channels, patterns, continuation, persist = false)
+        store1  <- storeRef.get
         changes <- store1.changes.map(
-                    collectActions[InsertContinuations[String, Pattern, StringsCaptor]]
-                  )
+                     collectActions[InsertContinuations[String, Pattern, StringsCaptor]],
+                   )
         // the operation should be on the list of changes
-        _      = changes should not be empty
-        _      <- space.revertToSoftCheckpoint(s1)
-        store2 <- storeRef.get
+        _        = changes should not be empty
+        _       <- space.revertToSoftCheckpoint(s1)
+        store2  <- storeRef.get
         changes <- store2.changes.map(
-                    collectActions[InsertContinuations[String, Pattern, StringsCaptor]]
-                  )
+                     collectActions[InsertContinuations[String, Pattern, StringsCaptor]],
+                   )
         // after reverting to the initial soft checkpoint the operation is no longer present in the hot store
-        _ = changes shouldBe empty
+        _        = changes shouldBe empty
       } yield ()
   }
 
@@ -1203,24 +1192,24 @@ trait StorageActionsTests[F[_]]
 
     for {
       // do an operation
-      _ <- space.consume(channels, patterns, continuation, persist = false)
+      _  <- space.consume(channels, patterns, continuation, persist = false)
       // create a soft checkpoint
       s1 <- space.createSoftCheckpoint()
       // do some other operation
       _  <- space.consume(channels, patterns, continuation, persist = true)
       s2 <- space.createSoftCheckpoint()
-      _  = s2.log should not be s1.log
+      _   = s2.log should not be s1.log
       _  <- space.revertToSoftCheckpoint(s1)
       s3 <- space.createSoftCheckpoint()
-      _  = s3.log shouldBe s1.log
+      _   = s3.log shouldBe s1.log
     } yield ()
   }
 }
 
 class InMemoryHotStoreStorageActionsTests
     extends InMemoryHotStoreTestsBase[IO]
-    with IOTests[String, Pattern, Nothing, String, StringsCaptor]
+    with IOTests[String, Pattern, Nothing, String, StringsCaptor, String]
     with StorageActionsTests[IO]
-    with StorageTestsBase[IO, String, Pattern, String, StringsCaptor] {
+    with StorageTestsBase[IO, String, Pattern, String, StringsCaptor, String] {
   implicit val parF: Parallel[IO] = IO.parallelForIO
 }

--- a/legacy/src/test/scala/coop/rchain/rspace/StorageExamplesTests.scala
+++ b/legacy/src/test/scala/coop/rchain/rspace/StorageExamplesTests.scala
@@ -13,266 +13,265 @@ import coop.rchain.rspace.util.{getK, runK, unpackOption}
 import scodec.Codec
 import cats.effect.unsafe.implicits.global
 
-trait StorageExamplesTests[F[_]]
-    extends StorageTestsBase[F, Channel, Pattern, Entry, EntriesCaptor] {
+trait StorageExamplesTests[F[_]] extends StorageTestsBase[F, Channel, Pattern, Entry, EntriesCaptor, Entry] {
 
   "CORE-365: A joined consume on duplicate channels followed by two produces on that channel" should
     "return a continuation and the produced data" in fixture { (store, _, space) =>
-    for {
-      r1 <- space
-             .consume(
-               List(Channel("friends"), Channel("friends")),
-               List(CityMatch(city = "Crystal Lake"), CityMatch(city = "Crystal Lake")),
-               new EntriesCaptor,
-               persist = false
-             )
-      _             = r1 shouldBe None
-      r2            <- space.produce(Channel("friends"), bob, persist = false)
-      _             = r2 shouldBe None
-      r3            <- space.produce(Channel("friends"), bob, persist = false)
-      _             = r3 shouldBe defined
-      _             = runK(unpackOption(r3))
-      _             = getK(r3).continuation.results shouldBe List(List(bob, bob))
-      insertActions <- store.changes.map(collectActions[InsertAction])
-      _             = insertActions shouldBe empty
-    } yield ()
-  }
+      for {
+        r1            <- space
+                           .consume(
+                             List(Channel("friends"), Channel("friends")),
+                             List(CityMatch(city = "Crystal Lake"), CityMatch(city = "Crystal Lake")),
+                             new EntriesCaptor,
+                             persist = false,
+                           )
+        _              = r1 shouldBe None
+        r2            <- space.produce(Channel("friends"), bob, persist = false)
+        _              = r2 shouldBe None
+        r3            <- space.produce(Channel("friends"), bob, persist = false)
+        _              = r3 shouldBe defined
+        _              = runK(unpackOption(r3))
+        _              = getK(r3).continuation.results shouldBe List(List(bob, bob))
+        insertActions <- store.changes.map(collectActions[InsertAction])
+        _              = insertActions shouldBe empty
+      } yield ()
+    }
 
   "CORE-365: Two produces on the same channel followed by a joined consume on duplicates of that channel" should
     "return a continuation and the produced data" in fixture { (store, _, space) =>
-    for {
-      r1 <- space.produce(Channel("friends"), bob, persist = false)
-      _  = r1 shouldBe None
-      r2 <- space.produce(Channel("friends"), bob, persist = false)
-      _  = r2 shouldBe None
-      r3 <- space
-             .consume(
-               List(Channel("friends"), Channel("friends")),
-               List(CityMatch(city = "Crystal Lake"), CityMatch(city = "Crystal Lake")),
-               new EntriesCaptor,
-               persist = false
-             )
-      _ = r3 shouldBe defined
-      _ = runK(unpackOption(r3))
-      _ = getK(r3).continuation.results shouldBe List(List(bob, bob))
-    } yield (store.changes.map(_.isEmpty shouldBe true))
-  }
+      for {
+        r1 <- space.produce(Channel("friends"), bob, persist = false)
+        _   = r1 shouldBe None
+        r2 <- space.produce(Channel("friends"), bob, persist = false)
+        _   = r2 shouldBe None
+        r3 <- space
+                .consume(
+                  List(Channel("friends"), Channel("friends")),
+                  List(CityMatch(city = "Crystal Lake"), CityMatch(city = "Crystal Lake")),
+                  new EntriesCaptor,
+                  persist = false,
+                )
+        _   = r3 shouldBe defined
+        _   = runK(unpackOption(r3))
+        _   = getK(r3).continuation.results shouldBe List(List(bob, bob))
+      } yield store.changes.map(_.isEmpty shouldBe true)
+    }
 
   "CORE-365: A joined consume on duplicate channels given twice followed by three produces" should
     "return a continuation and the produced data" in fixture { (store, _, space) =>
-    for {
-      r1 <- space
-             .consume(
-               List(Channel("colleagues"), Channel("friends"), Channel("friends")),
-               List(
-                 CityMatch(city = "Crystal Lake"),
-                 CityMatch(city = "Crystal Lake"),
-                 CityMatch(city = "Crystal Lake")
-               ),
-               new EntriesCaptor,
-               persist = false
-             )
-      _  = r1 shouldBe None
-      r2 <- space.produce(Channel("friends"), bob, persist = false)
-      _  = r2 shouldBe None
-      r3 <- space.produce(Channel("friends"), bob, persist = false)
-      _  = r3 shouldBe None
-      r4 <- space.produce(Channel("colleagues"), alice, persist = false)
-      _  = r4 shouldBe defined
-      _  = runK(unpackOption(r4))
-      _  = getK(r4).continuation.results shouldBe List(List(alice, bob, bob))
-    } yield (store.changes.map(_.isEmpty shouldBe true))
+      for {
+        r1 <- space
+                .consume(
+                  List(Channel("colleagues"), Channel("friends"), Channel("friends")),
+                  List(
+                    CityMatch(city = "Crystal Lake"),
+                    CityMatch(city = "Crystal Lake"),
+                    CityMatch(city = "Crystal Lake"),
+                  ),
+                  new EntriesCaptor,
+                  persist = false,
+                )
+        _   = r1 shouldBe None
+        r2 <- space.produce(Channel("friends"), bob, persist = false)
+        _   = r2 shouldBe None
+        r3 <- space.produce(Channel("friends"), bob, persist = false)
+        _   = r3 shouldBe None
+        r4 <- space.produce(Channel("colleagues"), alice, persist = false)
+        _   = r4 shouldBe defined
+        _   = runK(unpackOption(r4))
+        _   = getK(r4).continuation.results shouldBe List(List(alice, bob, bob))
+      } yield store.changes.map(_.isEmpty shouldBe true)
 
-  }
+    }
 
   "CORE-365: A joined consume on multiple duplicate channels followed by the requisite produces" should
     "return a continuation and the produced data" in fixture { (store, _, space) =>
-    for {
-      r1 <- space
-             .consume(
-               List(
-                 Channel("family"),
-                 Channel("family"),
-                 Channel("family"),
-                 Channel("family"),
-                 Channel("colleagues"),
-                 Channel("colleagues"),
-                 Channel("colleagues"),
-                 Channel("friends"),
-                 Channel("friends")
-               ),
-               List(
-                 CityMatch(city = "Herbert"),
-                 CityMatch(city = "Herbert"),
-                 CityMatch(city = "Herbert"),
-                 CityMatch(city = "Herbert"),
-                 CityMatch(city = "Crystal Lake"),
-                 CityMatch(city = "Crystal Lake"),
-                 CityMatch(city = "Crystal Lake"),
-                 CityMatch(city = "Crystal Lake"),
-                 CityMatch(city = "Crystal Lake")
-               ),
-               new EntriesCaptor,
-               persist = false
-             )
-      _   = r1 shouldBe None
-      r2  <- space.produce(Channel("friends"), bob, persist = false)
-      r3  <- space.produce(Channel("family"), carol, persist = false)
-      r4  <- space.produce(Channel("colleagues"), alice, persist = false)
-      r5  <- space.produce(Channel("friends"), bob, persist = false)
-      r6  <- space.produce(Channel("family"), carol, persist = false)
-      r7  <- space.produce(Channel("colleagues"), alice, persist = false)
-      r8  <- space.produce(Channel("colleagues"), alice, persist = false)
-      r9  <- space.produce(Channel("family"), carol, persist = false)
-      r10 <- space.produce(Channel("family"), carol, persist = false)
+      for {
+        r1  <- space
+                 .consume(
+                   List(
+                     Channel("family"),
+                     Channel("family"),
+                     Channel("family"),
+                     Channel("family"),
+                     Channel("colleagues"),
+                     Channel("colleagues"),
+                     Channel("colleagues"),
+                     Channel("friends"),
+                     Channel("friends"),
+                   ),
+                   List(
+                     CityMatch(city = "Herbert"),
+                     CityMatch(city = "Herbert"),
+                     CityMatch(city = "Herbert"),
+                     CityMatch(city = "Herbert"),
+                     CityMatch(city = "Crystal Lake"),
+                     CityMatch(city = "Crystal Lake"),
+                     CityMatch(city = "Crystal Lake"),
+                     CityMatch(city = "Crystal Lake"),
+                     CityMatch(city = "Crystal Lake"),
+                   ),
+                   new EntriesCaptor,
+                   persist = false,
+                 )
+        _    = r1 shouldBe None
+        r2  <- space.produce(Channel("friends"), bob, persist = false)
+        r3  <- space.produce(Channel("family"), carol, persist = false)
+        r4  <- space.produce(Channel("colleagues"), alice, persist = false)
+        r5  <- space.produce(Channel("friends"), bob, persist = false)
+        r6  <- space.produce(Channel("family"), carol, persist = false)
+        r7  <- space.produce(Channel("colleagues"), alice, persist = false)
+        r8  <- space.produce(Channel("colleagues"), alice, persist = false)
+        r9  <- space.produce(Channel("family"), carol, persist = false)
+        r10 <- space.produce(Channel("family"), carol, persist = false)
 
-      _ = r2 shouldBe None
-      _ = r3 shouldBe None
-      _ = r4 shouldBe None
-      _ = r5 shouldBe None
-      _ = r6 shouldBe None
-      _ = r7 shouldBe None
-      _ = r8 shouldBe None
-      _ = r9 shouldBe None
-      _ = r10 shouldBe defined
+        _ = r2 shouldBe None
+        _ = r3 shouldBe None
+        _ = r4 shouldBe None
+        _ = r5 shouldBe None
+        _ = r6 shouldBe None
+        _ = r7 shouldBe None
+        _ = r8 shouldBe None
+        _ = r9 shouldBe None
+        _ = r10 shouldBe defined
 
-      _ = runK(unpackOption(r10))
-      _ = getK(r10).continuation.results shouldBe List(
-        List(carol, carol, carol, carol, alice, alice, alice, bob, bob)
-      )
+        _ = runK(unpackOption(r10))
+        _ = getK(r10).continuation.results shouldBe List(
+              List(carol, carol, carol, carol, alice, alice, alice, bob, bob),
+            )
 
-    } yield (store.changes.map(_.isEmpty shouldBe true))
-  }
+      } yield store.changes.map(_.isEmpty shouldBe true)
+    }
 
   "CORE-365: Multiple produces on multiple duplicate channels followed by the requisite consume" should
     "return a continuation and the produced data" in fixture { (store, _, space) =>
-    for {
-      r1 <- space.produce(Channel("friends"), bob, persist = false)
-      r2 <- space.produce(Channel("family"), carol, persist = false)
-      r3 <- space.produce(Channel("colleagues"), alice, persist = false)
-      r4 <- space.produce(Channel("friends"), bob, persist = false)
-      r5 <- space.produce(Channel("family"), carol, persist = false)
-      r6 <- space.produce(Channel("colleagues"), alice, persist = false)
-      r7 <- space.produce(Channel("colleagues"), alice, persist = false)
-      r8 <- space.produce(Channel("family"), carol, persist = false)
-      r9 <- space.produce(Channel("family"), carol, persist = false)
+      for {
+        r1 <- space.produce(Channel("friends"), bob, persist = false)
+        r2 <- space.produce(Channel("family"), carol, persist = false)
+        r3 <- space.produce(Channel("colleagues"), alice, persist = false)
+        r4 <- space.produce(Channel("friends"), bob, persist = false)
+        r5 <- space.produce(Channel("family"), carol, persist = false)
+        r6 <- space.produce(Channel("colleagues"), alice, persist = false)
+        r7 <- space.produce(Channel("colleagues"), alice, persist = false)
+        r8 <- space.produce(Channel("family"), carol, persist = false)
+        r9 <- space.produce(Channel("family"), carol, persist = false)
 
-      _ = r1 shouldBe None
-      _ = r2 shouldBe None
-      _ = r3 shouldBe None
-      _ = r4 shouldBe None
-      _ = r5 shouldBe None
-      _ = r6 shouldBe None
-      _ = r7 shouldBe None
-      _ = r8 shouldBe None
-      _ = r9 shouldBe None
+        _ = r1 shouldBe None
+        _ = r2 shouldBe None
+        _ = r3 shouldBe None
+        _ = r4 shouldBe None
+        _ = r5 shouldBe None
+        _ = r6 shouldBe None
+        _ = r7 shouldBe None
+        _ = r8 shouldBe None
+        _ = r9 shouldBe None
 
-      r10 <- space
-              .consume(
-                List(
-                  Channel("family"),
-                  Channel("family"),
-                  Channel("family"),
-                  Channel("family"),
-                  Channel("colleagues"),
-                  Channel("colleagues"),
-                  Channel("colleagues"),
-                  Channel("friends"),
-                  Channel("friends")
-                ),
-                List(
-                  CityMatch(city = "Herbert"),
-                  CityMatch(city = "Herbert"),
-                  CityMatch(city = "Herbert"),
-                  CityMatch(city = "Herbert"),
-                  CityMatch(city = "Crystal Lake"),
-                  CityMatch(city = "Crystal Lake"),
-                  CityMatch(city = "Crystal Lake"),
-                  CityMatch(city = "Crystal Lake"),
-                  CityMatch(city = "Crystal Lake")
-                ),
-                new EntriesCaptor,
-                persist = false
-              )
+        r10 <- space
+                 .consume(
+                   List(
+                     Channel("family"),
+                     Channel("family"),
+                     Channel("family"),
+                     Channel("family"),
+                     Channel("colleagues"),
+                     Channel("colleagues"),
+                     Channel("colleagues"),
+                     Channel("friends"),
+                     Channel("friends"),
+                   ),
+                   List(
+                     CityMatch(city = "Herbert"),
+                     CityMatch(city = "Herbert"),
+                     CityMatch(city = "Herbert"),
+                     CityMatch(city = "Herbert"),
+                     CityMatch(city = "Crystal Lake"),
+                     CityMatch(city = "Crystal Lake"),
+                     CityMatch(city = "Crystal Lake"),
+                     CityMatch(city = "Crystal Lake"),
+                     CityMatch(city = "Crystal Lake"),
+                   ),
+                   new EntriesCaptor,
+                   persist = false,
+                 )
 
-      _ = r10 shouldBe defined
-      _ = runK(unpackOption(r10))
-      _ = getK(r10).continuation.results shouldBe List(
-        List(carol, carol, carol, carol, alice, alice, alice, bob, bob)
-      )
-    } yield (store.changes.map(_.isEmpty shouldBe true))
-  }
+        _ = r10 shouldBe defined
+        _ = runK(unpackOption(r10))
+        _ = getK(r10).continuation.results shouldBe List(
+              List(carol, carol, carol, carol, alice, alice, alice, bob, bob),
+            )
+      } yield store.changes.map(_.isEmpty shouldBe true)
+    }
 
   "CORE-365: A joined consume on multiple mixed up duplicate channels followed by the requisite produces" should
     "return a continuation and the produced data" in fixture { (store, _, space) =>
-    for {
-      r1 <- space
-             .consume(
-               List(
-                 Channel("family"),
-                 Channel("colleagues"),
-                 Channel("family"),
-                 Channel("friends"),
-                 Channel("friends"),
-                 Channel("family"),
-                 Channel("colleagues"),
-                 Channel("colleagues"),
-                 Channel("family")
-               ),
-               List(
-                 CityMatch(city = "Herbert"),
-                 CityMatch(city = "Crystal Lake"),
-                 CityMatch(city = "Herbert"),
-                 CityMatch(city = "Crystal Lake"),
-                 CityMatch(city = "Crystal Lake"),
-                 CityMatch(city = "Herbert"),
-                 CityMatch(city = "Crystal Lake"),
-                 CityMatch(city = "Crystal Lake"),
-                 CityMatch(city = "Herbert")
-               ),
-               new EntriesCaptor,
-               persist = false
-             )
+      for {
+        r1 <- space
+                .consume(
+                  List(
+                    Channel("family"),
+                    Channel("colleagues"),
+                    Channel("family"),
+                    Channel("friends"),
+                    Channel("friends"),
+                    Channel("family"),
+                    Channel("colleagues"),
+                    Channel("colleagues"),
+                    Channel("family"),
+                  ),
+                  List(
+                    CityMatch(city = "Herbert"),
+                    CityMatch(city = "Crystal Lake"),
+                    CityMatch(city = "Herbert"),
+                    CityMatch(city = "Crystal Lake"),
+                    CityMatch(city = "Crystal Lake"),
+                    CityMatch(city = "Herbert"),
+                    CityMatch(city = "Crystal Lake"),
+                    CityMatch(city = "Crystal Lake"),
+                    CityMatch(city = "Herbert"),
+                  ),
+                  new EntriesCaptor,
+                  persist = false,
+                )
 
-      _ = r1 shouldBe None
+        _ = r1 shouldBe None
 
-      r2  <- space.produce(Channel("friends"), bob, persist = false)
-      r3  <- space.produce(Channel("family"), carol, persist = false)
-      r4  <- space.produce(Channel("colleagues"), alice, persist = false)
-      r5  <- space.produce(Channel("friends"), bob, persist = false)
-      r6  <- space.produce(Channel("family"), carol, persist = false)
-      r7  <- space.produce(Channel("colleagues"), alice, persist = false)
-      r8  <- space.produce(Channel("colleagues"), alice, persist = false)
-      r9  <- space.produce(Channel("family"), carol, persist = false)
-      r10 <- space.produce(Channel("family"), carol, persist = false)
+        r2  <- space.produce(Channel("friends"), bob, persist = false)
+        r3  <- space.produce(Channel("family"), carol, persist = false)
+        r4  <- space.produce(Channel("colleagues"), alice, persist = false)
+        r5  <- space.produce(Channel("friends"), bob, persist = false)
+        r6  <- space.produce(Channel("family"), carol, persist = false)
+        r7  <- space.produce(Channel("colleagues"), alice, persist = false)
+        r8  <- space.produce(Channel("colleagues"), alice, persist = false)
+        r9  <- space.produce(Channel("family"), carol, persist = false)
+        r10 <- space.produce(Channel("family"), carol, persist = false)
 
-      _ = r2 shouldBe None
-      _ = r3 shouldBe None
-      _ = r4 shouldBe None
-      _ = r5 shouldBe None
-      _ = r6 shouldBe None
-      _ = r7 shouldBe None
-      _ = r8 shouldBe None
-      _ = r9 shouldBe None
-      _ = r10 shouldBe defined
+        _ = r2 shouldBe None
+        _ = r3 shouldBe None
+        _ = r4 shouldBe None
+        _ = r5 shouldBe None
+        _ = r6 shouldBe None
+        _ = r7 shouldBe None
+        _ = r8 shouldBe None
+        _ = r9 shouldBe None
+        _ = r10 shouldBe defined
 
-      _ = runK(unpackOption(r10))
-      _ = getK(r10).continuation.results shouldBe List(
-        List(carol, alice, carol, bob, bob, carol, alice, alice, carol)
-      )
-    } yield (store.changes.map(_.isEmpty shouldBe true))
-  }
+        _ = runK(unpackOption(r10))
+        _ = getK(r10).continuation.results shouldBe List(
+              List(carol, alice, carol, bob, bob, carol, alice, alice, carol),
+            )
+      } yield store.changes.map(_.isEmpty shouldBe true)
+    }
 }
 
 abstract class InMemoryHotStoreStorageExamplesTestsBase[F[_]]
-    extends StorageTestsBase[F, Channel, Pattern, Entry, EntriesCaptor] {
+    extends StorageTestsBase[F, Channel, Pattern, Entry, EntriesCaptor, Entry] {
 
   override def fixture[R](f: (ST, RefST, T) => F[R]): R = {
     val creator: (HR, ST) => F[(ST, RefST, T)] =
       (hr, ts) => {
         val atomicRef = Ref.of[F, ST](ts)
         atomicRef.map { ref =>
-          val space = new RSpace[F, Channel, Pattern, Entry, EntriesCaptor](hr, ref)
+          val space = new RSpace[F, Channel, Pattern, Entry, EntriesCaptor, Entry](hr, ref)
           (ts, ref, space)
         }
       }
@@ -282,7 +281,7 @@ abstract class InMemoryHotStoreStorageExamplesTestsBase[F[_]]
 
 class InMemoryHotStoreStorageExamplesTests
     extends InMemoryHotStoreStorageExamplesTestsBase[IO]
-    with IOTests[Channel, Pattern, Entry, Entry, EntriesCaptor]
+    with IOTests[Channel, Pattern, Entry, Entry, EntriesCaptor, Entry]
     with StorageExamplesTests[IO] {
   implicit val parF: Parallel[IO] = IO.parallelForIO
 }

--- a/legacy/src/test/scala/io/rhonix/rholang/normalizer/ContrNormalizerSpec.scala
+++ b/legacy/src/test/scala/io/rhonix/rholang/normalizer/ContrNormalizerSpec.scala
@@ -30,7 +30,7 @@ class ContrNormalizerSpec extends AnyFlatSpec with ScalaCheckPropertyChecks with
         // contract source (pattern1, pattern2, ... remainder) { continuation }
         val term = new PContr(source, listPatterns, remainder, continuation)
 
-        implicit val (nRec, bVScope, bVW, _, fVScope, _, fVR, infoWriter, _) = createMockDSL[IO, VarSort]()
+        implicit val (nRec, bVScope, bVW, bVR, fVScope, _, fVR, infoWriter, _) = createMockDSL[IO, VarSort]()
 
         val adt = ContractNormalizer.normalizeContract[IO, VarSort](term).unsafeRunSync()
 
@@ -82,7 +82,7 @@ class ContrNormalizerSpec extends AnyFlatSpec with ScalaCheckPropertyChecks with
 
       val initFreeVars = varsNameStr.distinct.zipWithIndex.map { case (name, index) => (name, (index, NameSort)) }.toMap
 
-      implicit val (nRec, bVScope, bVW, _, fVScope, _, fVR, infoWriter, _) =
+      implicit val (nRec, bVScope, bVW, bVR, fVScope, _, fVR, infoWriter, _) =
         createMockDSL[IO, VarSort](initFreeVars = initFreeVars)
 
       ContractNormalizer.normalizeContract[IO, VarSort](term).unsafeRunSync()

--- a/legacy/src/test/scala/io/rhonix/rholang/normalizer/InputNormalizerSpec.scala
+++ b/legacy/src/test/scala/io/rhonix/rholang/normalizer/InputNormalizerSpec.scala
@@ -48,7 +48,7 @@ class InputNormalizerSpec extends AnyFlatSpec with ScalaCheckPropertyChecks with
       // for (binds1 <- source1 & binds2 <- source2 & ...) { continuation }
       val term = new PInput(listReceipt, continuation)
 
-      implicit val (nRec, bVScope, bVW, _, fVScope, _, fVR, infoWriter, _) = createMockDSL[IO, VarSort]()
+      implicit val (nRec, bVScope, bVW, bVR, fVScope, _, fVR, infoWriter, _) = createMockDSL[IO, VarSort]()
 
       val adt = InputNormalizer.normalizeInput[IO, VarSort](term).unsafeRunSync()
 
@@ -105,7 +105,7 @@ class InputNormalizerSpec extends AnyFlatSpec with ScalaCheckPropertyChecks with
 
       val initFreeVars = varsNameStr.distinct.zipWithIndex.map { case (name, index) => (name, (index, NameSort)) }.toMap
 
-      implicit val (nRec, bVScope, bVW, _, fVScope, _, fVR, infoWriter, _) =
+      implicit val (nRec, bVScope, bVW, bVR, fVScope, _, fVR, infoWriter, _) =
         createMockDSL[IO, VarSort](initFreeVars = initFreeVars)
 
       InputNormalizer.normalizeInput[IO, VarSort](term).unsafeRunSync()
@@ -125,7 +125,7 @@ class InputNormalizerSpec extends AnyFlatSpec with ScalaCheckPropertyChecks with
     // for (pattern <= source) { Nil }
     val term         = new PInput(listReceipt, continuation)
 
-    implicit val (nRec, bVScope, bVW, _, fVScope, _, fVR, infoWriter, _) = createMockDSL[IO, VarSort]()
+    implicit val (nRec, bVScope, bVW, bVR, fVScope, _, fVR, infoWriter, _) = createMockDSL[IO, VarSort]()
 
     val adt = InputNormalizer.normalizeInput[IO, VarSort](term).unsafeRunSync()
 
@@ -147,7 +147,7 @@ class InputNormalizerSpec extends AnyFlatSpec with ScalaCheckPropertyChecks with
     // for (pattern <<- source) { Nil }
     val term         = new PInput(listReceipt, continuation)
 
-    implicit val (nRec, bVScope, bVW, _, fVScope, _, fVR, infoWriter, _) = createMockDSL[IO, VarSort]()
+    implicit val (nRec, bVScope, bVW, bVR, fVScope, _, fVR, infoWriter, _) = createMockDSL[IO, VarSort]()
 
     val adt = InputNormalizer.normalizeInput[IO, VarSort](term).unsafeRunSync()
 
@@ -168,7 +168,7 @@ class InputNormalizerSpec extends AnyFlatSpec with ScalaCheckPropertyChecks with
     val continuation = new PNil
     val term         = new PInput(listReceipt, continuation)
 
-    implicit val (nRec, bVScope, bVW, _, fVScope, _, fVR, infoWriter, _) = createMockDSL[IO, VarSort]()
+    implicit val (nRec, bVScope, bVW, bVR, fVScope, _, fVR, infoWriter, _) = createMockDSL[IO, VarSort]()
 
     val adt = InputNormalizer.normalizeInput[IO, VarSort](term).unsafeRunSync()
 
@@ -209,7 +209,7 @@ class InputNormalizerSpec extends AnyFlatSpec with ScalaCheckPropertyChecks with
 
     val term = new PInput(listReceipt, new PNil)
 
-    implicit val (nRec, bVScope, bVW, _, fVScope, _, fVR, infoWriter, _) = createMockDSL[IO, VarSort]()
+    implicit val (nRec, bVScope, bVW, bVR, fVScope, _, fVR, infoWriter, _) = createMockDSL[IO, VarSort]()
 
     val result = InputNormalizer.normalizeInput[IO, VarSort](term)
 
@@ -257,7 +257,7 @@ class InputNormalizerSpec extends AnyFlatSpec with ScalaCheckPropertyChecks with
       // for (receipt1; receipt2) { continuation }
       val term = new PInput(listReceipt, continuation)
 
-      implicit val (nRec, bVScope, bVW, _, fVScope, _, fVR, infoWriter, _) = createMockDSL[IO, VarSort]()
+      implicit val (nRec, bVScope, bVW, bVR, fVScope, _, fVR, infoWriter, _) = createMockDSL[IO, VarSort]()
 
       val adt = InputNormalizer.normalizeInput[IO, VarSort](term).unsafeRunSync()
 

--- a/legacy/src/test/scala/io/rhonix/rholang/normalizer/MatchNormalizerSpec.scala
+++ b/legacy/src/test/scala/io/rhonix/rholang/normalizer/MatchNormalizerSpec.scala
@@ -37,7 +37,7 @@ class MatchNormalizerSpec extends AnyFlatSpec with ScalaCheckPropertyChecks with
         // match target { case pattern1 => caseBody1; case pattern2 => caseBody2; ... }
         val inputTerm = new PMatch(targetTerm, listCases)
 
-        implicit val (nRec, bVScope, bVW, _, fVScope, _, fVR, infoWriter, _) = createMockDSL[IO, VarSort]()
+        implicit val (nRec, bVScope, bVW, bVR, fVScope, _, fVR, infoWriter, _) = createMockDSL[IO, VarSort]()
 
         val adt = MatchNormalizer.normalizeMatch[IO, VarSort](inputTerm).unsafeRunSync()
 
@@ -77,7 +77,7 @@ class MatchNormalizerSpec extends AnyFlatSpec with ScalaCheckPropertyChecks with
 
       val initFreeVars = varsNameStr.distinct.zipWithIndex.map { case (name, index) => (name, (index, ProcSort)) }.toMap
 
-      implicit val (nRec, bVScope, bVW, _, fVScope, _, fVR, infoWriter, _) =
+      implicit val (nRec, bVScope, bVW, bVR, fVScope, _, fVR, infoWriter, _) =
         createMockDSL[IO, VarSort](initFreeVars = initFreeVars)
 
       MatchNormalizer.normalizeMatch[IO, VarSort](term).unsafeRunSync()

--- a/legacy/src/test/scala/io/rhonix/rholang/normalizer/MatchesNormalizerSpec.scala
+++ b/legacy/src/test/scala/io/rhonix/rholang/normalizer/MatchesNormalizerSpec.scala
@@ -21,9 +21,9 @@ class MatchesNormalizerSpec extends AnyFlatSpec with ScalaCheckPropertyChecks wi
       val patternTerm = new PGround(new GroundString(patternStr))
       val matchesTerm = new PMatches(targetTerm, patternTerm)
 
-      implicit val (nRec, bVScope, _, _, fVScope, _, _, infoWriter, _) = createMockDSL[IO, VarSort]()
+      implicit val (nRec, bVScope, _, bVR, fVScope, _, _, infoWriter, _) = createMockDSL[IO, VarSort]()
 
-      val adt = MatchesNormalizer.normalizeMatches[IO](matchesTerm).unsafeRunSync()
+      val adt = MatchesNormalizer.normalizeMatches[IO, VarSort](matchesTerm).unsafeRunSync()
 
       val expectedAdt = EMatchesN(
         target = mockADT(targetTerm: Proc),

--- a/legacy/src/test/scala/io/rhonix/rholang/normalizer/VarNormalizerSpec.scala
+++ b/legacy/src/test/scala/io/rhonix/rholang/normalizer/VarNormalizerSpec.scala
@@ -25,7 +25,7 @@ class VarNormalizerSpec extends AnyFlatSpec with ScalaCheckPropertyChecks with M
       )
 
       val par = VarNormalizer.normalizeVar[IO, VarSort](term).unsafeRunSync()
-      par shouldBe BoundVarN(-1)
+      par shouldBe BoundVarN(varIndex)
     }
   }
 

--- a/legacy/src/test/scala/io/rhonix/rholang/normalizer/dsl/HistoryChainSpec.scala
+++ b/legacy/src/test/scala/io/rhonix/rholang/normalizer/dsl/HistoryChainSpec.scala
@@ -8,7 +8,7 @@ class HistoryChainSpec extends AnyFlatSpec with Matchers {
 
   "A HistoryChain" should "return the current element when calling current" in {
     val historyChain = HistoryChain(Seq(1, 2, 3))
-    historyChain.current() shouldBe 3
+    historyChain.current().get shouldBe 3
   }
 
   it should "return the correct depth when calling depth" in {
@@ -18,19 +18,19 @@ class HistoryChainSpec extends AnyFlatSpec with Matchers {
 
   it should "return an iterator when calling iter" in {
     val historyChain = HistoryChain(Seq(1, 2, 3))
-    historyChain.iter.toList shouldBe (List(1, 2, 3))
+    historyChain.iter.toList shouldBe List(1, 2, 3)
   }
 
   it should "append a new element when calling push" in {
     val historyChain = HistoryChain(Seq(1, 2, 3))
     historyChain.push(4)
-    historyChain.current() shouldBe 4
+    historyChain.current().get shouldBe 4
   }
 
   it should "append a copy of the last element when calling pushCopy" in {
     val historyChain = HistoryChain(Seq(1, 2, 3))
     historyChain.pushCopy()
-    historyChain.current() shouldBe 3
+    historyChain.current().get shouldBe 3
     historyChain.depth shouldBe 4
   }
 
@@ -38,7 +38,7 @@ class HistoryChainSpec extends AnyFlatSpec with Matchers {
     val historyChain  = HistoryChain(Seq(1, 2, 3))
     val poppedElement = historyChain.pop()
     poppedElement shouldBe 3
-    historyChain.current() shouldBe 2
+    historyChain.current().get shouldBe 2
   }
 
   "An empty HistoryChain" should "be created when calling empty" in {

--- a/legacy/src/test/scala/io/rhonix/rholang/normalizer/dsl/VarMapSpec.scala
+++ b/legacy/src/test/scala/io/rhonix/rholang/normalizer/dsl/VarMapSpec.scala
@@ -15,7 +15,7 @@ class VarMapSpec extends AnyFlatSpec with Matchers {
 
   it should "return the correct VarContext when getting an existing variable" in {
     val varMap = VarMap(Seq(("existingVar", 1, SourcePosition(0, 0))))
-    varMap.get("existingVar") shouldBe (Some(VarContext(0, 0, 1, SourcePosition(0, 0))))
+    varMap.get("existingVar") shouldBe Some(VarContext(0, 1, SourcePosition(0, 0)))
   }
 
   it should "return all variables when calling getAll" in {
@@ -26,15 +26,15 @@ class VarMapSpec extends AnyFlatSpec with Matchers {
       ),
     )
     varMap.data.toSeq should contain theSameElementsAs Seq(
-      ("var1", VarContext(0, -1, 1, SourcePosition(0, 0))),
-      ("var2", VarContext(1, -1, 2, SourcePosition(1, 1))),
+      ("var1", VarContext(0, 1, SourcePosition(0, 0))),
+      ("var2", VarContext(1, 2, SourcePosition(1, 1))),
     )
   }
 
   it should "update the VarContext when putting an existing variable" in {
     val varMap = VarMap(Seq(("existingVar", 1, SourcePosition(0, 0))))
       .put("existingVar", 2, SourcePosition(1, 1))
-    varMap._1.get("existingVar") shouldBe (Some(VarContext(1, 0, 2, SourcePosition(1, 1))))
+    varMap._1.get("existingVar") shouldBe (Some(VarContext(1, 2, SourcePosition(1, 1))))
   }
 
   it should "increment the de Bruijn index when putting a new variable" in {

--- a/legacy/src/test/scala/io/rhonix/rholang/normalizer/dsl/VarMapSpec.scala
+++ b/legacy/src/test/scala/io/rhonix/rholang/normalizer/dsl/VarMapSpec.scala
@@ -9,7 +9,7 @@ import org.scalatest.matchers.should.Matchers
 class VarMapSpec extends AnyFlatSpec with Matchers {
 
   "A VarMap" should "return None when getting a non-existing variable" in {
-    val varMap = VarMap.default[Int]
+    val varMap = VarMap.default[Int]()
     varMap.get("nonExistingVar") shouldBe None
   }
 

--- a/legacy/src/test/scala/io/rhonix/rholang/normalizer/util/MockBoundVarReader.scala
+++ b/legacy/src/test/scala/io/rhonix/rholang/normalizer/util/MockBoundVarReader.scala
@@ -5,7 +5,7 @@ import io.rhonix.rholang.normalizer.util.Mock.DefPosition
 
 case class MockBoundVarReader[T](boundVars: Map[String, (Int, T)]) extends BoundVarReader[T] {
   private val boundVarMap: Map[String, VarContext[T]] =
-    boundVars.map { case (name, (index, varType)) => name -> VarContext(index, -1, varType, DefPosition) }
+    boundVars.map { case (name, (index, varType)) => name -> VarContext(index, varType, DefPosition) }
 
   override def getBoundVar(name: String): Option[VarContext[T]] = boundVarMap.get(name)
 

--- a/legacy/src/test/scala/io/rhonix/rholang/normalizer/util/MockBoundVarReader.scala
+++ b/legacy/src/test/scala/io/rhonix/rholang/normalizer/util/MockBoundVarReader.scala
@@ -11,4 +11,6 @@ case class MockBoundVarReader[T](boundVars: Map[String, (Int, T)]) extends Bound
 
   override def findBoundVar(name: String): Option[VarContext[T]] =
     boundVarMap.get(name)
+
+  override def getNextIndex: Int = if (boundVarMap.isEmpty) 0 else boundVarMap.values.map(_.index).max + 1
 }

--- a/legacy/src/test/scala/io/rhonix/rholang/normalizer/util/MockBoundVarWriter.scala
+++ b/legacy/src/test/scala/io/rhonix/rholang/normalizer/util/MockBoundVarWriter.scala
@@ -15,7 +15,7 @@ case class MockBoundVarWriter[F[_], T](scope: MockBoundVarScope[F]) extends Boun
     buffer.appendAll(bindings.map { case (name, varType, _) =>
       BoundVarWriterData(name, varType, newScopeLevel, copyScopeLevel)
     })
-    bindings.zipWithIndex.map { case ((_, t, pos), i) => VarContext(i, -1, t, pos) }
+    bindings.zipWithIndex.map { case ((_, t, pos), i) => VarContext(i, t, pos) }
   }
 
   def extractData: Seq[BoundVarWriterData[T]] = buffer.toSeq

--- a/legacy/src/test/scala/io/rhonix/rholang/normalizer/util/MockFreeVarScope.scala
+++ b/legacy/src/test/scala/io/rhonix/rholang/normalizer/util/MockFreeVarScope.scala
@@ -7,7 +7,7 @@ import io.rhonix.rholang.normalizer.env.FreeVarScope
 case class MockFreeVarScope[F[_]: Sync]() extends FreeVarScope[F] {
   private var scopeLevel: Int = 0
 
-  override def withNewFreeVarScope[R](scopeFn: F[R]): F[R] = for {
+  override def withNewFreeVarScope[R](scopeFn: F[R], startIndex: Int = 0): F[R] = for {
     _   <- Sync[F].delay(scopeLevel += 1)
     res <- scopeFn
     _    = scopeLevel -= 1

--- a/legacy/src/test/scala/io/rhonix/rholang/normalizer/util/MockFreeVarWriter.scala
+++ b/legacy/src/test/scala/io/rhonix/rholang/normalizer/util/MockFreeVarWriter.scala
@@ -13,7 +13,7 @@ case class MockFreeVarWriter[F[_], T](scope: MockFreeVarScope[F]) extends FreeVa
     binding.zipWithIndex.map { case ((name, varType, pos), i) =>
       val scopeLevel = scope.getScopeLevel
       buffer.append(FreeVarWriterData(name, varType, scopeLevel))
-      VarContext(DefFreeVarIndex + i, -1, varType, pos)
+      VarContext(DefFreeVarIndex + i, varType, pos)
     }
 
   def extractData: Seq[FreeVarWriterData[T]] = buffer.toSeq


### PR DESCRIPTION
## Overview
This PR implements solution 2 as described in https://github.com/nzpr/gorki-node/discussions/27.
Early on in https://github.com/nzpr/gorki-node/pull/31, we were returning indices from the matcher during dispatch.
Now, we have aligned the indices of BreeVar and BoundVar (with help start index):
https://github.com/nzpr/gorki-node/blob/114ba11f084ea1a27a88dc869c5670d1aa32d658/legacy/src/main/scala/io/rhonix/rholang/normalizer/env/FreeVarScope.scala#L11
For this purpose, we retrieve this index during pattern processing from the BoundVarMap and subsequently transmit it to the FreeVarMap:
https://github.com/nzpr/gorki-node/blob/114ba11f084ea1a27a88dc869c5670d1aa32d658/legacy/src/main/scala/io/rhonix/rholang/normalizer/syntax/NormalizerSyntax.scala#L24-L33

Then, afterward, we can simply change the ordering of indexing in the normalizer and in the reducer.
https://github.com/nzpr/gorki-node/pull/33/commits/9e3ceb1f0bc50493af441c84e0168be8bd0aa207

### Notes

<!-- Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else. -->

### Please make sure that this PR:

- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
